### PR TITLE
Shutoff setpoint check

### DIFF
--- a/dev/HPWH.cc
+++ b/dev/HPWH.cc
@@ -322,6 +322,11 @@ int HPWH::runOneStep(double inletT_C, double drawVolume_L,
   }
 
 
+  //cursory check for inverted temperature profile
+  if (tankTemps_C[numNodes] < tankTemps_C[0]) {
+    if (hpwhVerbosity >= VRB_reluctant) msg("The top of the tank is cooler than the bottom.  \n");
+  }
+  
 
   if (simHasFailed) {
     if (hpwhVerbosity >= VRB_reluctant) msg("The simulation has encountered an error.  \n");
@@ -1442,6 +1447,15 @@ bool HPWH::HeatSource::shouldHeat(double heatSourceAmbientT_C) const {
 
 bool HPWH::HeatSource::shutsOff(double heatSourceAmbientT_C) const {
   bool shutOff = false;
+
+  if (hpwh->tankTemps_C[0] >= hpwh->setpoint_C) {
+    shutOff = true;
+    if (hpwh->hpwhVerbosity >= VRB_emetic){
+      hpwh->msg("shutsOff  bottom node hot: %.2d C  \n returns true", hpwh->tankTemps_C[0]);
+    }
+    return shutOff;
+  }
+  
 
   for (int i = 0; i < (int)shutOffLogicSet.size(); i++) {
     if (hpwh->hpwhVerbosity >= VRB_emetic){

--- a/dev/HPWH.hh
+++ b/dev/HPWH.hh
@@ -20,7 +20,7 @@ class HPWH {
  public:
   static const int version_major = 1;
   static const int version_minor = 2;
-  static const int version_maint = 4;
+  static const int version_maint = 5;
 
 
   static const float DENSITYWATER_kgperL;


### PR DESCRIPTION
There as a small error where when a compressor tried to heat a tank that was already all at setpoint, it would make the heat distribution all -nan's.  I fixed it by checking in the shutsOff function to see if the bottom node was at setpoint already.  I also added a warning message to indicate if the bottom of the tank was warmer than the top.  
