### PR TITLE
Fix targeting temperature higher than setpoint for integrated units.

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -869,7 +869,7 @@ int HPWH::setTankSize_adjustUA(double HPWH_size, UNITS units  /*=UNITS_L*/) {
 	// as the outer dimenisions of the whole unit.
 	double radius = getTankRadius(vol, volUnits, UNITS_FT);
 
-	double value = 2. * 3.14159 * pow(radius, 2) * (ASPECTRATIO + 1);
+	double value = 2. * 3.14159 * pow(radius, 2) * (ASPECTRATIO + 1.);
 
 	if (value >= 0.)
 	{	if (surfAUnits == UNITS_M2)
@@ -1276,7 +1276,7 @@ double HPWH::getNthSimTcouple(int iTCouple, int nTCouple, UNITS units  /*=UNITS_
 	}
 	else {
 		double weight = (double)numNodes / (double)nTCouple;
-		double start_ind = (iTCouple - 1) * weight;
+		double start_ind = (iTCouple - 1.) * weight;
 		int ind = (int)std::ceil(start_ind);
 
 		double averageTemp_C = 0.0;
@@ -2553,6 +2553,10 @@ double HPWH::HeatSource::addHeatAboveNode(double cap_kJ, int node, double minute
 		//otherwise the target temp is the first non-equal-temp node
 		else {
 			targetTemp_C = hpwh->tankTemps_C[setPointNodeNum + 1];
+		}
+		// With DR tomfoolery make sure the target temperature doesn't exceed the setpoint.
+		if (targetTemp_C > hpwh->setpoint_C) {
+			targetTemp_C = hpwh->setpoint_C;
 		}
 
 		deltaT_C = targetTemp_C - hpwh->tankTemps_C[setPointNodeNum];


### PR DESCRIPTION
Fix bug for integrated (wrapped heat exchangers) tanks with setpoint changes. When the bottom node was below the setpoint but the rest of the tank was above the setpoint the target temperature for adding heat would be the node above the bottom node. So the bottom node would overshoot the setpoint temperature trying to reach the second to bottom node. Fixed to target the setpoint temperature if the target temperature is greater than the setpoint. 

