### PR TITLE
AO Smith CAHP 120

### DIFF
--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -80,6 +80,7 @@ class HPWH {
 	  MODELS_AOSmithHPTU66 = 105,    /**< 66 gallon AOSmith HPTU */
 	  MODELS_AOSmithHPTU80 = 106,    /**< 80 gallon AOSmith HPTU */
 	  MODELS_AOSmithHPTU80_DR = 107,    /**< 80 gallon AOSmith HPTU */
+	  MODELS_AOSmithCAHP120 = 108, /**< 12 gallon AOSmith CAHP commercial grade */
 
 	  // GE Models
 	  MODELS_GE2012 = 110,      /**<  The 2012 era GeoSpring  */
@@ -242,11 +243,14 @@ class HPWH {
 	HeatingLogic bottomHalf(double d) const;
 	HeatingLogic bottomTwelth(double d) const;
 	HeatingLogic bottomSixth(double d) const;
+	HeatingLogic bottomSixth_absolute(double d) const;
 	HeatingLogic secondSixth(double d) const;
 	HeatingLogic thirdSixth(double d) const;
 	HeatingLogic fourthSixth(double d) const;
 	HeatingLogic fifthSixth(double d) const;
 	HeatingLogic topSixth(double d) const;
+	HeatingLogic topSixth_absolute(double d) const;
+
   HeatingLogic standby(double d) const;
   HeatingLogic topNodeMaxTemp(double d) const;
   HeatingLogic bottomNodeMaxTemp(double d) const;
@@ -387,6 +391,7 @@ class HPWH {
   static double getTankRadius(double vol, UNITS volUnits = UNITS_L, UNITS radiusUnits = UNITS_FT);
   /**< Returns the tank surface radius based off of real storage tanks*/
 
+  bool isTankSizeFixed() const;  /**< is the tank size allowed to be changed */
   int setTankSize(double HPWH_size, UNITS units = UNITS_L);
   /**< Defualt units L. This is a simple setter for the tank volume in L or GAL */
 
@@ -537,6 +542,9 @@ class HPWH {
 
 	bool setpointFixed;
 	/**< does the HPWH allow the setpoint to vary  */
+
+	bool tankSizeFixed;
+	/**< does the HPWH have a constant tank size or can it be changed  */
 
   VERBOSITY hpwhVerbosity;
 	/**< an enum to let the sim know how much output to say  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,11 @@
 # Build test tool
 include_directories("${PROJECT_BINARY_DIR}/src")
 
-add_executable(testTool main.cc)
+add_executable(testTool main.cc )
+add_executable(testTankSizeFixed testTankSizeFixed.cc)
 
 target_link_libraries(testTool libHPWHsim)
+target_link_libraries(testTankSizeFixed libHPWHsim)
 
 # Add output directory for test results
 add_custom_target(results_directory ALL COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/output")
@@ -25,7 +27,6 @@ set(testNames
  testDr_TOT
  testDr_TOO2
  testDR_TOTLOR
- testTankSizeFixed
 )
 
 set(modelNames
@@ -66,7 +67,6 @@ set(largeCompressorTests
  testLargeComp45
  testLargeComp60
  testLargeCompHot
- testTankSizeFixed
 )
 set(largeCompressorNames
   ColmacCxV_5_SP
@@ -98,6 +98,31 @@ set(yearLargeTestsModels
 set(yearLargeTests                                        
   testCA_36Unit_CTZ12
 )
+
+# Unit tests
+function( add_TankSizeFixed_test )
+  set(options)
+  set(oneValueArgs MODEL_NAME)
+  set(multValueArgs)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
+
+  set(testArgs "${ARG_MODEL_NAME}")
+
+  set(TEST_TITLE "TankSizeFixed.${ARG_MODEL_NAME}")
+
+  add_test(NAME "${TEST_TITLE}" COMMAND  $<TARGET_FILE:testTankSizeFixed> ${testArgs}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+endfunction()
+
+foreach(model ${modelNames})
+	add_TankSizeFixed_test( MODEL_NAME "${model}")
+endforeach(model)
+foreach(model ${largeCompressorNames})
+	add_TankSizeFixed_test( MODEL_NAME "${model}")
+endforeach(model)
+
+
 
 #Tests for successful runs
 function( add_model_test )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,7 @@ set(testNames
  testDr_TOT
  testDr_TOO2
  testDR_TOTLOR
+ testTankSizeFixed
 )
 
 set(modelNames
@@ -65,6 +66,7 @@ set(largeCompressorTests
  testLargeComp45
  testLargeComp60
  testLargeCompHot
+ testTankSizeFixed
 )
 set(largeCompressorNames
   ColmacCxV_5_SP

--- a/test/main.cc
+++ b/test/main.cc
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 
   const double EBALTHRESHOLD = 0.005;
 
-  const int nTestTCouples = 6;
+  const int nTestTCouples = 12;
   // Schedule stuff
   std::vector<string> scheduleNames;
   std::vector<schedule> allSchedules(6);
@@ -180,6 +180,9 @@ int main(int argc, char *argv[])
 		model = HPWH::MODELS_Rheem2020Build80;
 	}
 	// Large HPWH's
+	else if (input2 == "AOSmithCAHP120") {
+		model = HPWH::MODELS_AOSmithCAHP120;
+	}
 	else if (input2 == "ColmacCxV_5_SP") {
 		model = HPWH::MODELS_ColmacCxV_5_SP;
 	} else if (input2 == "ColmacCxA_10_SP") {

--- a/test/main.cc
+++ b/test/main.cc
@@ -9,6 +9,7 @@
  *
  */
 #include "HPWH.hh"
+#include "testUtilityFcts.cc"
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -42,7 +43,7 @@ int main(int argc, char *argv[])
 
   const double EBALTHRESHOLD = 0.005;
 
-  const int nTestTCouples = 12;
+  const int nTestTCouples = 6;
   // Schedule stuff
   std::vector<string> scheduleNames;
   std::vector<schedule> allSchedules(6);
@@ -116,107 +117,9 @@ int main(int argc, char *argv[])
   newSetpoint = 0;
   if(input1 == "Preset") {
     inputFile = "";
-    if(input2 == "Voltex60" || input2 == "AOSmithPHPT60") {
-		model = HPWH::MODELS_AOSmithPHPT60;
-    } else if(input2 == "Voltex80" || input2 == "AOSmith80") {
-		model = HPWH::MODELS_AOSmithPHPT80;
-    } else if(input2 == "GEred" || input2 == "GE") {
-		model = HPWH::MODELS_GE2012;
-	} else if (input2 == "SandenGAU" || input2 == "Sanden80" || input2 == "SandenGen3") {
-		model = HPWH::MODELS_Sanden80;
-	} else if (input2 == "Sanden120") {
-		model = HPWH::MODELS_Sanden120;
-    } else if(input2 == "SandenGES" || input2 == "Sanden40") {
-		model = HPWH::MODELS_Sanden40;
-    } else if(input2 == "AOSmithHPTU50") {
-		model = HPWH::MODELS_AOSmithHPTU50;
-    } else if(input2 == "AOSmithHPTU66") {
-		model = HPWH::MODELS_AOSmithHPTU66;
-    } else if(input2 == "AOSmithHPTU80") {
-		model = HPWH::MODELS_AOSmithHPTU80;
-    } else if(input2 == "AOSmithHPTU80DR") {
-		model = HPWH::MODELS_AOSmithHPTU80_DR;
-    } else if(input2 == "GE502014STDMode" || input2 == "GE2014STDMode") {
-		model = HPWH::MODELS_GE2014STDMode;
-    } else if(input2 == "GE502014" || input2 == "GE2014") {
-		model = HPWH::MODELS_GE2014;
-    } else if(input2 == "GE802014") {
-		model = HPWH::MODELS_GE2014_80DR;
-    } else if(input2 == "RheemHB50") {
-		model = HPWH::MODELS_RheemHB50;
-    } else if(input2 == "Stiebel220e" || input2 == "Stiebel220E") {
-		model = HPWH::MODELS_Stiebel220E;
-    } else if(input2 == "Generic1") {
-		model = HPWH::MODELS_Generic1;
-    } else if(input2 == "Generic2") {
-		model = HPWH::MODELS_Generic2;
-    } else if(input2 == "Generic3") {
-		model = HPWH::MODELS_Generic3;
-    } else if(input2 == "custom") {
-		model = HPWH::MODELS_CustomFile;
-	} else if (input2 == "restankRealistic") {
-		model = HPWH::MODELS_restankRealistic;
-	} else if(input2 == "StorageTank") {
-		model = HPWH::MODELS_StorageTank;
-	} else if(input2 == "BWC2020_65"){
-		model = HPWH::MODELS_BWC2020_65;
-	} 
-	// New Rheems
-	else if (input2 == "Rheem2020Prem40") {
-	  model = HPWH::MODELS_Rheem2020Prem40;
-	} else if (input2 == "Rheem2020Prem50") {
-		model = HPWH::MODELS_Rheem2020Prem50;
-	} else if (input2 == "Rheem2020Prem65") {
-		model = HPWH::MODELS_Rheem2020Prem65;
-	} else if (input2 == "Rheem2020Prem80") {
-		model = HPWH::MODELS_Rheem2020Prem80;
-	} else if (input2 == "Rheem2020Build40") {
-		model = HPWH::MODELS_Rheem2020Build40;
-	} else if (input2 == "Rheem2020Build50") {
-		model = HPWH::MODELS_Rheem2020Build50;
-	} else if (input2 == "Rheem2020Build65") {
-		model = HPWH::MODELS_Rheem2020Build65;
-	} else if (input2 == "Rheem2020Build80") {
-		model = HPWH::MODELS_Rheem2020Build80;
-	}
-	// Large HPWH's
-	else if (input2 == "AOSmithCAHP120") {
-		model = HPWH::MODELS_AOSmithCAHP120;
-	}
-	else if (input2 == "ColmacCxV_5_SP") {
-		model = HPWH::MODELS_ColmacCxV_5_SP;
-	} else if (input2 == "ColmacCxA_10_SP") {
-		model = HPWH::MODELS_ColmacCxA_10_SP;
-	} else if (input2 == "ColmacCxA_15_SP") {
-		model = HPWH::MODELS_ColmacCxA_15_SP;
-	} else if (input2 == "ColmacCxA_20_SP") {
-		model = HPWH::MODELS_ColmacCxA_20_SP;
-	} else if (input2 == "ColmacCxA_25_SP") {
-		model = HPWH::MODELS_ColmacCxA_25_SP;
-	} else if (input2 == "ColmacCxA_30_SP") {
-		model = HPWH::MODELS_ColmacCxA_30_SP;
-	} else if (input2 == "NyleC25A_SP") {
-		model = HPWH::MODELS_NyleC25A_SP;
-	} else if (input2 == "NyleC90A_SP") {
-		model = HPWH::MODELS_NyleC90A_SP;
-	} else if (input2 == "NyleC185A_SP") {
-		model = HPWH::MODELS_NyleC185A_SP;
-	} else if (input2 == "NyleC250A_SP") {
-		model = HPWH::MODELS_NyleC250A_SP;
-	} else if (input2 == "NyleC90A_C_SP") {
-		model = HPWH::MODELS_NyleC90A_C_SP;
-	} else if (input2 == "NyleC185A_C_SP") {
-		model = HPWH::MODELS_NyleC185A_C_SP;
-	} else if (input2 == "NyleC250A_C_SP") {
-		model = HPWH::MODELS_NyleC250A_C_SP;
+    
+	model = mapStringToPreset(input2);
 
-	//do nothin, use custom-compiled input specified later
-
-    } else {
-      model = HPWH::MODELS_basicIntegrated;
-      cout << "Couldn't find model " << input2 << ".  Exiting...\n";
-      exit(1);
-    }
     if (hpwh.HPWHinit_presets(model) != 0) exit(1);
     if(model == HPWH::MODELS_Sanden80 || model == HPWH::MODELS_Sanden40) {
       newSetpoint = (149 - 32) / 1.8;

--- a/test/main.cc
+++ b/test/main.cc
@@ -49,7 +49,7 @@ int main(int argc, char *argv[])
 
   string testDirectory, fileToOpen, fileToOpen2, scheduleName, var1, input1, input2, input3, inputFile, outputDirectory;
   string inputVariableName, firstCol;
-  double testVal, newSetpoint, airTemp, airTemp2, tempDepressThresh, inletH, tot_limit;
+  double testVal, newSetpoint, airTemp, airTemp2, tempDepressThresh, inletH, newTankSize, tot_limit;
   int i, outputCode;
   long minutesToRun;
 
@@ -244,6 +244,7 @@ int main(int argc, char *argv[])
   doCondu = 1;
   doInvMix = 1;
   inletH = 0.;
+  newTankSize = 0.;
   tot_limit = 0.;
   cout << "Running: " << input2 << ", " << input1 << ", " << input3 << endl;
 
@@ -262,6 +263,9 @@ int main(int argc, char *argv[])
 	}
 	else if(var1 == "inletH") {
 		inletH = testVal;
+	}
+	else if (var1 == "tanksize") {
+		newTankSize = testVal;
 	}
 	else if(var1 == "tot_limit") {
 		tot_limit = testVal;
@@ -317,6 +321,9 @@ int main(int argc, char *argv[])
   }
   if (inletH > 0) {
 	  outputCode += hpwh.setInletByFraction(inletH);
+  }
+  if (newTankSize > 0) {
+	  hpwh.setTankSize(newTankSize, HPWH::UNITS_GAL);
   }
   if (tot_limit > 0) {
 	  outputCode += hpwh.setTimerLimitTOT(tot_limit);

--- a/test/testTankSizeFixed.cc
+++ b/test/testTankSizeFixed.cc
@@ -1,0 +1,75 @@
+
+
+/*unit test for isTankSizeFixed() functionality
+ *
+ *
+ *
+ */
+#include "HPWH.hh"
+#include "testUtilityFcts.cc"
+
+#include <iostream>
+#include <string> 
+
+using std::cout;
+using std::string;
+
+int main(int argc, char *argv[])
+{
+	HPWH hpwh;
+	HPWH::MODELS model;
+
+	string input;
+
+	if (argc != 2) {
+		cout << "Invalid input. This program takes One arguments: preset model specification (ie. Sanden80). Recieved input: \n";
+		for (int ii = 0; ii < argc; ii++) {
+			cout << argv[ii] << " ";
+		}
+		exit(1);
+	}
+	else {
+		input = argv[1];
+	}
+
+	// get model number
+	model = mapStringToPreset(input);
+
+	// set preset
+	if (hpwh.HPWHinit_presets(model) != 0) exit(1);
+
+	double originalTankSize = hpwh.getTankSize();
+	double newTankSize = originalTankSize + 100;
+
+	// change the tank size
+	int result = hpwh.setTankSize(newTankSize);
+
+	if (result != 0 && result != HPWH::HPWH_ABORT) {
+		cout << "Error, setTankSize() returned an invalid result: " << result <<"\n";
+	}
+
+	if (hpwh.isTankSizeFixed()) { // better not have change!
+		if (result == 0) {
+			cout << "Error, setTankSize() returned 0 when should be HPWH_ABORT\n";
+			exit(1);
+		}
+		if (originalTankSize != hpwh.getTankSize()) {
+			cout << "Error, the tank size has changed when isTankSizeFixed is true\n";
+			exit(1);
+		}
+	}
+	else { // it better have changed
+		if (result != 0) {
+			cout << "Error, setTankSize() returned HPWH_ABORT when it should be 0\n";
+			exit(1);
+		}
+		if (newTankSize != hpwh.getTankSize()) {
+			cout << "Error, the tank size hasn't changed to the new tank size when it should have. New Size: " << newTankSize << ". Returned Value: "<< hpwh.getTankSize() <<"\n";
+			exit(1);
+		}
+	}
+
+	//Made it through the gauntlet
+	return 0;
+
+}

--- a/test/testTankSizeFixed/DRschedule.csv
+++ b/test/testTankSizeFixed/DRschedule.csv
@@ -1,0 +1,2 @@
+default 0
+minutes,OnOff

--- a/test/testTankSizeFixed/ambientTschedule.csv
+++ b/test/testTankSizeFixed/ambientTschedule.csv
@@ -1,0 +1,1 @@
+default 20

--- a/test/testTankSizeFixed/drawschedule.csv
+++ b/test/testTankSizeFixed/drawschedule.csv
@@ -1,0 +1,6 @@
+default 0,
+minutes,flow_out_gal
+2,10
+3,10
+4,10
+5,10

--- a/test/testTankSizeFixed/evaporatorTschedule.csv
+++ b/test/testTankSizeFixed/evaporatorTschedule.csv
@@ -1,0 +1,1 @@
+default 20

--- a/test/testTankSizeFixed/inletTschedule.csv
+++ b/test/testTankSizeFixed/inletTschedule.csv
@@ -1,0 +1,2 @@
+default 15,
+minutes,inlet_T

--- a/test/testTankSizeFixed/testInfo.txt
+++ b/test/testTankSizeFixed/testInfo.txt
@@ -1,0 +1,3 @@
+length_of_test 10
+setpoint 52
+tanksize 114

--- a/test/testUtilityFcts.cc
+++ b/test/testUtilityFcts.cc
@@ -1,0 +1,166 @@
+/*This is not a substitute for a proper HPWH Test Tool, it is merely a short program
+ * to aid in the testing of the new HPWH.cc as it is being written.
+ *
+ * -NDK
+ *
+ * Bring on the HPWH Test Tool!!! -MJL
+ *
+ *
+ *
+ */
+#include "HPWH.hh"
+#include <iostream>
+#include <string> 
+
+using std::cout;
+using std::string;
+
+HPWH::MODELS mapStringToPreset(string modelName);
+
+HPWH::MODELS mapStringToPreset(string modelName) {
+
+	HPWH::MODELS hpwhModel;
+
+	if(modelName == "Voltex60" || modelName == "AOSmithPHPT60") {
+		hpwhModel = HPWH::MODELS_AOSmithPHPT60;
+	}
+	else if (modelName == "Voltex80" || modelName == "AOSmith80") {
+		hpwhModel = HPWH::MODELS_AOSmithPHPT80;
+	}
+	else if (modelName == "GEred" || modelName == "GE") {
+		hpwhModel = HPWH::MODELS_GE2012;
+	}
+	else if (modelName == "SandenGAU" || modelName == "Sanden80" || modelName == "SandenGen3") {
+		hpwhModel = HPWH::MODELS_Sanden80;
+	}
+	else if (modelName == "Sanden120") {
+		hpwhModel = HPWH::MODELS_Sanden120;
+	}
+	else if (modelName == "SandenGES" || modelName == "Sanden40") {
+		hpwhModel = HPWH::MODELS_Sanden40;
+	}
+	else if (modelName == "AOSmithHPTU50") {
+		hpwhModel = HPWH::MODELS_AOSmithHPTU50;
+	}
+	else if (modelName == "AOSmithHPTU66") {
+		hpwhModel = HPWH::MODELS_AOSmithHPTU66;
+	}
+	else if (modelName == "AOSmithHPTU80") {
+		hpwhModel = HPWH::MODELS_AOSmithHPTU80;
+	}
+	else if (modelName == "AOSmithHPTU80DR") {
+		hpwhModel = HPWH::MODELS_AOSmithHPTU80_DR;
+	}
+	else if (modelName == "GE502014STDMode" || modelName == "GE2014STDMode") {
+		hpwhModel = HPWH::MODELS_GE2014STDMode;
+	}
+	else if (modelName == "GE502014" || modelName == "GE2014") {
+		hpwhModel = HPWH::MODELS_GE2014;
+	}
+	else if (modelName == "GE802014") {
+		hpwhModel = HPWH::MODELS_GE2014_80DR;
+	}
+	else if (modelName == "RheemHB50") {
+		hpwhModel = HPWH::MODELS_RheemHB50;
+	}
+	else if (modelName == "Stiebel220e" || modelName == "Stiebel220E") {
+		hpwhModel = HPWH::MODELS_Stiebel220E;
+	}
+	else if (modelName == "Generic1") {
+		hpwhModel = HPWH::MODELS_Generic1;
+	}
+	else if (modelName == "Generic2") {
+		hpwhModel = HPWH::MODELS_Generic2;
+	}
+	else if (modelName == "Generic3") {
+		hpwhModel = HPWH::MODELS_Generic3;
+	}
+	else if (modelName == "custom") {
+		hpwhModel = HPWH::MODELS_CustomFile;
+	}
+	else if (modelName == "restankRealistic") {
+		hpwhModel = HPWH::MODELS_restankRealistic;
+	}
+	else if (modelName == "StorageTank") {
+		hpwhModel = HPWH::MODELS_StorageTank;
+	}
+	else if (modelName == "BWC2020_65") {
+		hpwhModel = HPWH::MODELS_BWC2020_65;
+	}
+	// New Rheems
+	else if (modelName == "Rheem2020Prem40") {
+		hpwhModel = HPWH::MODELS_Rheem2020Prem40;
+	}
+	else if (modelName == "Rheem2020Prem50") {
+		hpwhModel = HPWH::MODELS_Rheem2020Prem50;
+	}
+	else if (modelName == "Rheem2020Prem65") {
+		hpwhModel = HPWH::MODELS_Rheem2020Prem65;
+	}
+	else if (modelName == "Rheem2020Prem80") {
+		hpwhModel = HPWH::MODELS_Rheem2020Prem80;
+	}
+	else if (modelName == "Rheem2020Build40") {
+		hpwhModel = HPWH::MODELS_Rheem2020Build40;
+	}
+	else if (modelName == "Rheem2020Build50") {
+		hpwhModel = HPWH::MODELS_Rheem2020Build50;
+	}
+	else if (modelName == "Rheem2020Build65") {
+		hpwhModel = HPWH::MODELS_Rheem2020Build65;
+	}
+	else if (modelName == "Rheem2020Build80") {
+		hpwhModel = HPWH::MODELS_Rheem2020Build80;
+	}
+	// Large HPWH's
+	else if (modelName == "AOSmithCAHP120") {
+		hpwhModel = HPWH::MODELS_AOSmithCAHP120;
+	}
+	else if (modelName == "ColmacCxV_5_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxV_5_SP;
+	}
+	else if (modelName == "ColmacCxA_10_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxA_10_SP;
+	}
+	else if (modelName == "ColmacCxA_15_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxA_15_SP;
+	}
+	else if (modelName == "ColmacCxA_20_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxA_20_SP;
+	}
+	else if (modelName == "ColmacCxA_25_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxA_25_SP;
+	}
+	else if (modelName == "ColmacCxA_30_SP") {
+		hpwhModel = HPWH::MODELS_ColmacCxA_30_SP;
+	}
+	else if (modelName == "NyleC25A_SP") {
+		hpwhModel = HPWH::MODELS_NyleC25A_SP;
+	}
+	else if (modelName == "NyleC90A_SP") {
+		hpwhModel = HPWH::MODELS_NyleC90A_SP;
+	}
+	else if (modelName == "NyleC185A_SP") {
+		hpwhModel = HPWH::MODELS_NyleC185A_SP;
+	}
+	else if (modelName == "NyleC250A_SP") {
+		hpwhModel = HPWH::MODELS_NyleC250A_SP;
+	}
+	else if (modelName == "NyleC90A_C_SP") {
+		hpwhModel = HPWH::MODELS_NyleC90A_C_SP;
+	}
+	else if (modelName == "NyleC185A_C_SP") {
+		hpwhModel = HPWH::MODELS_NyleC185A_C_SP;
+	}
+	else if (modelName == "NyleC250A_C_SP") {
+		hpwhModel = HPWH::MODELS_NyleC250A_C_SP;
+
+		//do nothin, use custom-compiled input specified later
+	}
+	else {
+		hpwhModel = HPWH::MODELS_basicIntegrated;
+		cout << "Couldn't find model " << modelName << ".  Exiting...\n";
+		exit(1);
+	}
+	return hpwhModel;
+}


### PR DESCRIPTION
- HPWHsim model name: MODELS_AOSmithCAHP120.
- Introduces tankSizeFixed variable for integrated units.
  - MODELS_Sanden_GS3_45HPA_US_SP is the one Sanden unit with tankSizeFixed = false.
- CAHP120 model still being refined.
- Add unit testTestTankSizeFixed
  - Provides a frame work for adding unit tests in the future. Is making a new executable the best way or should it be wrapped in the old testTool?
