### PR TITLE
Set Defaults Function in Constructor

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -67,15 +67,17 @@ const std::string HPWH::version_maint = HPWHVRSN_META;
 
 //the HPWH functions
 //the publics
-HPWH::HPWH() :
-	simHasFailed(true), isHeating(false), setpointFixed(false), tankSizeFixed(true), canScale(false), hpwhVerbosity(VRB_silent),
-	messageCallback(NULL), messageCallbackContextPtr(NULL), numHeatSources(0),
-	setOfSources(NULL), tankTemps_C(NULL), nextTankTemps_C(NULL), doTempDepression(false), 
-	locationTemperature_C(UNINITIALIZED_LOCATIONTEMP),
-	doInversionMixing(true), doConduction(true), 
-	inletHeight(0), inlet2Height(0), fittingsUA_kJperHrC(0.),
-	prevDRstatus(DR_ALLOW), timerLimitTOT(60.), timerTOT(0.)
-{  }
+HPWH::HPWH() { setAllDefaults(); };
+
+void HPWH::setAllDefaults() {
+	simHasFailed = true; isHeating = false; setpointFixed = false; tankSizeFixed = true; canScale = false; hpwhVerbosity = VRB_silent;
+	messageCallback = NULL; messageCallbackContextPtr = NULL; numHeatSources = 0;
+	setOfSources = NULL; tankTemps_C = NULL; nextTankTemps_C = NULL; doTempDepression = false;
+	locationTemperature_C = UNINITIALIZED_LOCATIONTEMP;
+	doInversionMixing = true; doConduction = true;
+	inletHeight = 0; inlet2Height = 0; fittingsUA_kJperHrC = 0.;
+	prevDRstatus = DR_ALLOW; timerLimitTOT = 60.; timerTOT = 0.;
+}
 
 HPWH::HPWH(const HPWH &hpwh) {
 	simHasFailed = hpwh.simHasFailed;
@@ -3197,13 +3199,10 @@ int HPWH::checkInputs() {
 
 #ifndef HPWH_ABRIDGED
 int HPWH::HPWHinit_file(string configFile) {
-	simHasFailed = true;  //this gets cleared on successful completion of init
 
-	//clear out old stuff if you're re-initializing
-	delete[] tankTemps_C;
-	delete[] nextTankTemps_C;
-	delete[] setOfSources;
-
+	setAllDefaults(); // reset all defaults if you're re-initilizing
+	// sets simHasFailed = true; this gets cleared on successful completion of init
+	// return 0 on success, HPWH_ABORT for failure
 
 	//open file, check and report errors
 	std::ifstream inputFILE;

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -67,9 +67,13 @@ const std::string HPWH::version_maint = HPWHVRSN_META;
 
 //the HPWH functions
 //the publics
-HPWH::HPWH() { setAllDefaults(); };
+HPWH::HPWH() : setOfSources(NULL), tankTemps_C(NULL), nextTankTemps_C(NULL) { setAllDefaults(); };
 
 void HPWH::setAllDefaults() {
+	delete[] tankTemps_C;
+	delete[] nextTankTemps_C;
+	delete[] setOfSources;
+
 	simHasFailed = true; isHeating = false; setpointFixed = false; tankSizeFixed = true; canScale = false; hpwhVerbosity = VRB_silent;
 	messageCallback = NULL; messageCallbackContextPtr = NULL; numHeatSources = 0;
 	setOfSources = NULL; tankTemps_C = NULL; nextTankTemps_C = NULL; doTempDepression = false;

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -51,6 +51,7 @@ class HPWH {
   HPWH & operator=(const HPWH &hpwh);  /**< assignment operator  */
 	~HPWH(); /**< destructor just a couple dynamic arrays to destroy - could be replaced by vectors eventually?   */
 
+
   ///specifies the various modes for the Demand Response (DR) abilities
   ///values may vary - names should be used
 	enum DRMODES {
@@ -275,7 +276,8 @@ class HPWH {
   /**< This function returns a string with the current version number */
 
 	int HPWHinit_presets(MODELS presetNum);
-	/**< This function will load in a set of parameters that are hardcoded in this function -
+	/**< This function will reset all member variables to defaults and then
+	 * load in a set of parameters that are hardcoded in this function -
 	 * which particular set of parameters is selected by presetNum.
 	 * This is similar to the way the HPWHsim currently operates, as used in SEEM,
 	 * but not quite as versatile.
@@ -533,6 +535,8 @@ class HPWH {
 
  private:
   class HeatSource;
+
+  void setAllDefaults(); /**< sets all the defaults default */
 
 	void updateTankTemps(double draw, double inletT, double ambientT, double inletVol2_L, double inletT2_L);
 	void mixTankInversions();

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -8,9 +8,6 @@ int HPWH::HPWHinit_resTank() {
 	return this->HPWHinit_resTank(GAL_TO_L(47.5), 0.95, 4500, 4500);
 }
 int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W) {
-	//clear out old stuff if you're re-initializing
-	//delete[] tankTemps_C;
-	//delete[] setOfSources;
 
 	setAllDefaults(); // reset all defaults if you're re-initilizing
 	// sets simHasFailed = true; this gets cleared on successful completion of init
@@ -295,10 +292,6 @@ int HPWH::HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double res
 
 
 int HPWH::HPWHinit_presets(MODELS presetNum) {
-
-	//clear out old stuff if you're re-initializing
-	//delete[] tankTemps_C;
-	//delete[] setOfSources;
 
 	setAllDefaults(); // reset all defaults if you're re-initilizing
 	// sets simHasFailed = true; this gets cleared on successful completion of init

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -8,6 +8,14 @@ int HPWH::HPWHinit_resTank() {
 	return this->HPWHinit_resTank(GAL_TO_L(47.5), 0.95, 4500, 4500);
 }
 int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W) {
+	//clear out old stuff if you're re-initializing
+	//delete[] tankTemps_C;
+	//delete[] setOfSources;
+
+	setAllDefaults(); // reset all defaults if you're re-initilizing
+	// sets simHasFailed = true; this gets cleared on successful completion of init
+	// return 0 on success, HPWH_ABORT for failure
+
 	//low power element will cause divide by zero/negative UA in EF -> UA conversion
 	if (lowerPower_W < 550) {
 		if (hpwhVerbosity >= VRB_reluctant) {
@@ -105,15 +113,10 @@ int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPo
 }
 
 int HPWH::HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double resUse_C) {
-	//return 0 on success, HPWH_ABORT for failure
-	simHasFailed = true;  //this gets cleared on successful completion of init
 
-	//clear out old stuff if you're re-initializing
-	delete[] tankTemps_C;
-	delete[] setOfSources;
-
-
-
+	setAllDefaults(); // reset all defaults if you're re-initilizing
+	// sets simHasFailed = true; this gets cleared on successful completion of init
+	// return 0 on success, HPWH_ABORT for failure
 
 	//except where noted, these values are taken from MODELS_GE2014STDMode on 5/17/16
 	numNodes = 12;
@@ -292,13 +295,14 @@ int HPWH::HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double res
 
 
 int HPWH::HPWHinit_presets(MODELS presetNum) {
-	//return 0 on success, HPWH_ABORT for failure
-	simHasFailed = true;  //this gets cleared on successful completion of init
 
 	//clear out old stuff if you're re-initializing
-	delete[] tankTemps_C;
-	delete[] setOfSources;
+	//delete[] tankTemps_C;
+	//delete[] setOfSources;
 
+	setAllDefaults(); // reset all defaults if you're re-initilizing
+	// sets simHasFailed = true; this gets cleared on successful completion of init
+	// return 0 on success, HPWH_ABORT for failure
 
 	//resistive with no UA losses for testing
 	if (presetNum == MODELS_restankNoUA) {


### PR DESCRIPTION
Defaults moved into function called in constructor and out of initialization list. This is recalled during preset or file model initialization to avoid carrying over non default values for variables in the case of re-initialization of a preset on the same object.