### PR TITLE
getSizingFractions(double &aquafract, double &percentUseable)

### DIFF
--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -540,6 +540,12 @@ class HPWH {
   int getHPWHModel() const;
   /**< get the model number of the HPWHsim model number of the hpwh */
 
+  void getSizingFractions(double &aquafract, double &percentUseable) const;
+  /**< returns the fraction of total tank volume from the bottom up where the aquastat is
+  or the turn on logic for the compressor, and the USEable fraction of storage or 1 minus
+  where the shut off logic is for the compressor. If the logic spans multiple nodes it 
+  returns the weighted average of the nodes */
+
   bool isHPWHScalable() const;
   /**< returns if the HPWH is scalable or not*/
 
@@ -573,8 +579,9 @@ class HPWH {
 	/**< adds extra heat defined by the user. Where nodeExtraHeat[] is a vector of heat quantities to be added during the step.  nodeExtraHeat[ 0] would go to bottom node, 1 to next etc.  */
 
   double tankAvg_C(const std::vector<NodeWeight> nodeWeights) const;
-
 	/**< functions to calculate what the temperature in a portion of the tank is  */
+  double nodeWeightAvgFract(HeatingLogic logic) const;
+  /**< function to calculate where the average node for a logic set is. */
 
   void calcDerivedValues();
 	/**< a helper function for the inits, calculating condentropy and the lowest node  */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,11 +5,13 @@ add_executable(testTool main.cc )
 add_executable(testTankSizeFixed testTankSizeFixed.cc)
 add_executable(testScaleHPWH testScaleHPWH.cc)
 add_executable(testMaxSetpoint testMaxSetpoint.cc)
+add_executable(testSizingFractions testSizingFractions.cc)
 
 target_link_libraries(testTool libHPWHsim)
 target_link_libraries(testTankSizeFixed libHPWHsim)
 target_link_libraries(testScaleHPWH libHPWHsim)
 target_link_libraries(testMaxSetpoint libHPWHsim)
+target_link_libraries(testSizingFractions libHPWHsim)
 
 # Add output directory for test results
 add_custom_target(results_directory ALL COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/output")
@@ -21,6 +23,7 @@ add_test(NAME "Ready.Output.Files" COMMAND ${CMAKE_COMMAND} -E remove "${CMAKE_C
 # Run Unit tests
 add_test(NAME "testScaleHPWH" COMMAND  $<TARGET_FILE:testScaleHPWH> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME "testMaxSetpoint" COMMAND  $<TARGET_FILE:testMaxSetpoint> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME "testSizingFractions" COMMAND  $<TARGET_FILE:testMaxSetpoint> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 
 #add_test(NAME "testREGoesTo99C.AOSmithCAHP120" COMMAND $<TARGET_FILE:testTool> "Preset" "AOSmithCAHP120" "testREGoesTo99C"

--- a/test/testSizingFractions.cc
+++ b/test/testSizingFractions.cc
@@ -1,0 +1,100 @@
+
+
+/*unit test for isTankSizeFixed() functionality
+ *
+ *
+ *
+ */
+#include "HPWH.hh"
+#include "testUtilityFcts.cc"
+
+#include <iostream>
+#include <string> 
+
+#define SIZE (double)HPWH::CONDENSITY_SIZE
+
+using std::cout;
+using std::string;
+
+void testScalableSizingFract();
+void testSandenSizingFract();
+void testColmacSizingFract();
+void testHPTU50SizingFract();
+void test220eSizingFract();
+
+int main(int argc, char *argv[])
+{
+	testScalableSizingFract();
+	testSandenSizingFract();
+	testColmacSizingFract();
+	testHPTU50SizingFract();
+	test220eSizingFract();
+	//Made it through the gauntlet
+	return 0;
+}
+
+
+void testScalableSizingFract() {
+	HPWH hpwh;
+	double AF, pU;
+	double AF_answer = 4. / SIZE;
+
+	string input = "TamScalable_SP"; // Just a compressor with R134A
+	getHPWHObject(hpwh, input); 	// get preset model 
+
+	hpwh.getSizingFractions( AF, pU);
+	ASSERTTRUE(cmpd(AF, AF_answer));
+	ASSERTTRUE(cmpd(pU, 1 - 1. / SIZE));
+}
+
+void testSandenSizingFract() {
+	HPWH hpwh;
+	double AF, pU;
+	double AF_answer = 8. / SIZE;
+
+	string input = "Sanden80"; // Just a compressor with R134A
+	getHPWHObject(hpwh, input); 	// get preset model 
+
+	hpwh.getSizingFractions(AF, pU);
+	ASSERTTRUE(cmpd(AF, AF_answer));
+	ASSERTTRUE(cmpd(pU, 1 - 1. / SIZE));
+}
+
+void testColmacSizingFract() {
+	HPWH hpwh;
+	double AF, pU;
+	double AF_answer = 4. / SIZE;
+
+	string input = "ColmacCxV_5_SP"; // Just a compressor with R134A
+	getHPWHObject(hpwh, input); 	// get preset model 
+
+	hpwh.getSizingFractions(AF, pU);
+	ASSERTTRUE(cmpd(AF, AF_answer));
+	ASSERTTRUE(cmpd(pU, 1 - 1. / SIZE));
+}
+
+void testHPTU50SizingFract() {
+	HPWH hpwh;
+	double AF, pU;
+	double AF_answer = (1. + 2. + 3. + 4.) / 4. / SIZE;
+
+	string input = "AOSmithHPTU50"; // Just a compressor with R134A
+	getHPWHObject(hpwh, input); 	// get preset model 
+
+	hpwh.getSizingFractions(AF, pU);
+	ASSERTTRUE(cmpd(AF, AF_answer));
+	ASSERTTRUE(cmpd(pU, 1.));
+}
+
+void test220eSizingFract() {
+	HPWH hpwh;
+	double AF, pU;
+	double AF_answer = (5. + 6.) / 2. / SIZE;
+
+	string input = "Stiebel220e"; // Just a compressor with R134A
+	getHPWHObject(hpwh, input); 	// get preset model 
+
+	hpwh.getSizingFractions(AF, pU);
+	ASSERTTRUE(cmpd(AF, AF_answer));
+	ASSERTTRUE(cmpd(pU, 1 - 1./SIZE));
+}


### PR DESCRIPTION

- void HPWH::getSizingFractions(double &aquafract, double &percentUseable)
  -returns the fraction of total tank volume from the bottom up where the aquastat is or the turn on logic for the compressor, and the USEable fraction of storage or 1 minus where the shut off logic is for the compressor. If the logic spans multiple nodes it returns the weighted average of the nodes