### PR TITLE
Catch edge cases in fractToMeetComparisonExternal

### DIFF
--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -1174,7 +1174,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.addTurnOnLogic(HPWH::HeatingLogic("eighth node absolute", nodeWeights, F_TO_C(113), true));
 		if (presetNum == MODELS_Sanden80 || presetNum == MODELS_Sanden120) {
 			compressor.addTurnOnLogic(HPWH::standby(dF_TO_dC(8.2639)));
-
+			// Adds a bonus standby logic so the external heater does not cycle, recommended for any external heater with standby
 			std::vector<NodeWeight> nodeWeightStandby;
 			nodeWeightStandby.emplace_back(0);
 			compressor.standbyLogic = new HPWH::HeatingLogic("bottom node absolute", nodeWeightStandby, F_TO_C(113), true, std::greater<double>());

--- a/test/main.cc
+++ b/test/main.cc
@@ -17,7 +17,6 @@
 #include <algorithm>    // std::max
 
 #define MAX_DIR_LENGTH 255
-#define DEBUG 0
 
 using std::cout;
 using std::endl;
@@ -65,9 +64,9 @@ int main(int argc, char *argv[])
   string strHead = "minutes,Ta,Tsetpoint,inletT,draw,";
 //  string strHead = "minutes,Ta,Tsetpoint,inletT,draw,condenserT,";
   
-  if (DEBUG) {
-	 hpwh.setVerbosity(HPWH::VRB_reluctant);
-  }
+#if defined _DEBUG
+  hpwh.setVerbosity(HPWH::VRB_reluctant);
+#endif
 
   //.......................................
   //process command line arguments
@@ -116,7 +115,11 @@ int main(int argc, char *argv[])
   if(input1 == "Preset") {
     inputFile = "";
     
-	getHPWHObject(hpwh, input2);
+	if (getHPWHObject(hpwh, input2) == HPWH::HPWH_ABORT) {
+		cout << "Error, preset model did not initialize.\n";
+		exit(1);
+	}
+
 	model = static_cast<HPWH::MODELS> (hpwh.getHPWHModel());
 
     if(model == HPWH::MODELS_Sanden80 || model == HPWH::MODELS_Sanden40) {
@@ -262,9 +265,9 @@ int main(int argc, char *argv[])
   // Loop over the minutes in the test
   for (i = 0; i < minutesToRun; i++) {
 
-	  if (DEBUG) {
-		  cout << "Now on minute: " << i << "\n";
-	  }
+#if defined _DEBUG && 0
+	  cout << "Now on minute: " << i << "\n";
+#endif
 
 	  if (HPWH_doTempDepress) {
 		  airTemp2 = F_TO_C(airTemp);
@@ -432,13 +435,6 @@ int readSchedule(schedule &scheduleArray, string scheduleFileName, long minutesO
 			}
 		}
   }
-  
-  //print out the whole schedule
-// if(DEBUG == 1){
-//   for(i = 0; (unsigned)i < scheduleArray.size(); i++){
-//     cout << "scheduleArray[" << i << "] = " << scheduleArray[i] << "\n";
-//   }
-// }
 
   inputFile.close();
 


### PR DESCRIPTION
- Catch case if difference is <= 0 in denominator. Would imply that we are not getting closer to the shut off condition if true.
- Catch case if numerator is <= 0, implies that shut off condition is already met. 
- Also generalized to use the bottom node of any shut off logic.
- Switched from #define DEBUG to preprocessor _DEBUG in testTool