### PR TITLE
Cmake option to omit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,5 +21,11 @@ endif()
 
 find_package(Git QUIET)
 
+if (HPWHSIM_ABRIDGED)
+  add_compile_definitions( HPWH_ABRIDGED)
+endif()
+
 add_subdirectory(src)
-add_subdirectory(test)
+if (NOT HPWHSIM_OMIT_TESTTOOL)
+  add_subdirectory(test)
+endif()


### PR DESCRIPTION
Note to future self: the option exists in the CMakeCache.txt, and can be changed in there if the build isn't building the tests