### PR TITLE
Commercial res tank

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -1539,6 +1539,14 @@ int HPWH::getCompressorIndex() const {
 	return compressorIndex;
 }
 
+int HPWH::getNumResistanceElements() const {
+	int count = 0;
+	for (int i = 0; i < numHeatSources; i++) {
+		count += setOfSources[i].isAResistance() ? 1 : 0;
+	}
+	return count;
+}
+
 double HPWH::getCompressorCapacity(double airTemp /*=19.722*/, double inletTemp /*=14.444*/, double outTemp /*=57.222*/, 
 	UNITS pwrUnit /*=UNITS_KW*/, UNITS tempUnit /*=UNITS_C*/) const {
 	// calculate capacity btu/hr, input btu/hr, and cop
@@ -1958,7 +1966,7 @@ int HPWH::setCompressorOutputCapacity(double newCapacity, double airTemp /*=19.7
 }
 
 
-int HPWH::setResistanceCapacity(double power, int which /*=0*/, UNITS pwrUnit /*=UNITS_KW*/) {
+int HPWH::setResistanceCapacity(double power, int which /*=-1*/, UNITS pwrUnit /*=UNITS_KW*/) {
 
 	//Input checks
 	if (!isHPWHScalable()) {
@@ -1967,9 +1975,15 @@ int HPWH::setResistanceCapacity(double power, int which /*=0*/, UNITS pwrUnit /*
 		}
 		return HPWH_ABORT;
 	}
-	if (lowestElementIndex == -1) {
+	if (getNumResistanceElements() == 0) {
 		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("There are no resistance elements to change \n");
+			msg("There are no resistance elements to set capacity for \n");
+		}
+		return HPWH_ABORT;
+	}
+	if (which < -1 || which > getNumResistanceElements() - 1) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Out of bounds value for which in setResistanceCapacity()\n");
 		}
 		return HPWH_ABORT;
 	}
@@ -1995,69 +2009,65 @@ int HPWH::setResistanceCapacity(double power, int which /*=0*/, UNITS pwrUnit /*
 	}
 
 	//Whew so many checks...
-	if (which == 0) {
+	if (which == -1) {
+		// Just get all the elements
 		for (int i = 0; i < numHeatSources; i++) {
 			if (setOfSources[i].isAResistance()) {
 				setOfSources[i].changeResistanceWatts(watts);
 			}
 		}
 	}
-	else if (which == 1) {
-		setOfSources[lowestElementIndex].changeResistanceWatts(watts);
-	}
-	else if (which == 2) {
-		if (highestElementIndex == -1) {
-			if (hpwhVerbosity >= VRB_reluctant) {
-				msg("There is no upper resistance element to set \n");
-			}
-			return HPWH_ABORT;
-		}
-		setOfSources[highestElementIndex].changeResistanceWatts(watts);
-	}
 	else {
-		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("The which option must be between 0 and 2 \n");
+		setOfSources[resistanceHeightMap[which].index].changeResistanceWatts(watts);
+
+		// Then check for repeats in the position
+		int pos = resistanceHeightMap[which].position;
+		for (int i = 0; i < getNumResistanceElements(); i++) {
+			if (resistanceHeightMap[i].position == pos) {
+				setOfSources[resistanceHeightMap[i].index].changeResistanceWatts(watts);
+			}
 		}
-		return HPWH_ABORT;
 	}
 
 	return 0;
 }
-double HPWH::getResistanceCapacity(int which /*=0*/, UNITS pwrUnit /*=UNITS_KW*/) {
+
+double HPWH::getResistanceCapacity(int which /*=-1*/, UNITS pwrUnit /*=UNITS_KW*/) {
 
 	//Input checks
-	if (lowestElementIndex == -1) {
+	if (getNumResistanceElements() == 0) {
 		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("There are no resistance elements to return \n");
+			msg("There are no resistance elements to return capacity for \n");
 		}
 		return HPWH_ABORT;
 	}
-	
+	if (which < -1 || which > getNumResistanceElements() - 1) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Out of bounds value for which in getResistanceCapacity()\n");
+		}
+		return HPWH_ABORT;
+	}
+
 	double returnPower = 0;
-	if (which == 0) {
+	if (which == -1) {
+		// Just get all the elements
 		for (int i = 0; i < numHeatSources; i++) {
 			if (setOfSources[i].isAResistance()) {
 				returnPower += setOfSources[i].perfMap[0].inputPower_coeffs[0];
 			}
 		}
 	}
-	else if (which == 1) {
-		returnPower = setOfSources[lowestElementIndex].perfMap[0].inputPower_coeffs[0];
-	}
-	else if (which == 2) {
-		if (highestElementIndex == -1) {
-			if (hpwhVerbosity >= VRB_reluctant) {
-				msg("There is no upper resistance element to get \n");
-			}
-			return HPWH_ABORT;
-		}
-		returnPower = setOfSources[highestElementIndex].perfMap[0].inputPower_coeffs[0];
-	}
 	else {
-		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("The which option must be between 0 and 2 \n");
+		// get the power from "which" element by height
+		returnPower += setOfSources[resistanceHeightMap[which].index].perfMap[0].inputPower_coeffs[0];
+
+		// Then check for repeats in the position
+		int pos = resistanceHeightMap[which].position;
+		for (int i = 0; i < getNumResistanceElements(); i++) {
+			if (resistanceHeightMap[i].position == pos) {
+				returnPower += setOfSources[resistanceHeightMap[i].index].perfMap[0].inputPower_coeffs[0];
+			}
 		}
-		return HPWH_ABORT;
 	}
 
 	//Unit conversion
@@ -2075,6 +2085,31 @@ double HPWH::getResistanceCapacity(int which /*=0*/, UNITS pwrUnit /*=UNITS_KW*/
 	}
 
 	return returnPower;
+}
+
+int HPWH::getResistancePosition(int elementIndex) const {
+
+	if (elementIndex < 0 || elementIndex > numHeatSources - 1) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Out of bounds value for which in getResistancePosition\n");
+		}
+		return HPWH_ABORT;
+	}
+
+	if (!setOfSources[elementIndex].isAResistance()) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("This index is not a resistance element\n");
+		}
+		return HPWH_ABORT;
+	}
+
+	int elementPosition = -1;
+	for (int i = 0; i < CONDENSITY_SIZE; i++) {
+		if (setOfSources[elementIndex].condensity[i] == 1) { // res elements have a condenstiy of 1 at a specific node
+			return i;
+		}
+	}
+	return HPWH_ABORT;
 }
 
 //the privates
@@ -3540,6 +3575,8 @@ void HPWH::calcDerivedValues() {
 
 	calcSizeConstants();
 
+	mapResRelativePosToSetOfSources();
+
 	//heat source ability to depress temp
 	for (int i = 0; i < numHeatSources; i++) {
 		if (setOfSources[i].isACompressor()) {
@@ -3607,7 +3644,7 @@ void HPWH::calcDerivedHeatingValues(){
 	highestElementIndex = -1; // Default = No resistance elements
 	VIPIndex = -1; // Default = No VIP element
 	int lowestElementPos = CONDENSITY_SIZE;
-	int highestElementPos = 0;
+	int highestElementPos = 0; // -1 to make sure a an element on the bottom can still be identified.
 	for (int i = 0; i < numHeatSources; i++) {
 		if (setOfSources[i].isACompressor()) {
 			compressorIndex = i;  // NOTE: Maybe won't work with multiple compressors (last compressor will be used)
@@ -3629,18 +3666,18 @@ void HPWH::calcDerivedHeatingValues(){
 					lowestElementIndex = i;
 					lowestElementPos = j;
 				}
-				if (setOfSources[i].condensity[j] > 0.0 && j > highestElementPos) {
+				if (setOfSources[i].condensity[j] > 0.0 && j >= highestElementPos) {
 					highestElementIndex = i;
 					highestElementPos = j;
 				}
 			}
 		}
 	}
-
 	if (hpwhVerbosity >= VRB_emetic) {
 		msg(outputString, " compressorIndex : %d \n", compressorIndex);
 		msg(outputString, " lowestElementIndex : %d \n", lowestElementIndex);
-	}	
+		msg(outputString, " highestElementIndex : %d \n", highestElementIndex);
+	}
 	if (hpwhVerbosity >= VRB_emetic) {
 		msg(outputString, " VIPIndex : %d \n", VIPIndex);
 	}
@@ -3655,6 +3692,25 @@ void HPWH::calcDerivedHeatingValues(){
 		}
 	}
 
+}
+
+void HPWH::mapResRelativePosToSetOfSources() {
+	resistanceHeightMap.clear();
+	resistanceHeightMap.reserve(getNumResistanceElements());
+
+	for (int i = 0; i < numHeatSources; i++) {
+		if (setOfSources[i].isAResistance()) {
+			resistanceHeightMap.push_back({ i,
+											getResistancePosition(i)
+				});
+		}
+	}
+
+	// Sort by height, low to high
+	std::sort(resistanceHeightMap.begin(), resistanceHeightMap.end(),
+		[](const HPWH::resPoint & a, const HPWH::resPoint & b) -> bool {
+		return a.position < b.position; // (5 < 5)      // evaluates to false 
+	});
 }
 
 bool HPWH::areNodeWeightsValid(HPWH::HeatingLogic logic) {

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -2023,7 +2023,7 @@ int HPWH::setResistanceCapacity(double power, int which /*=-1*/, UNITS pwrUnit /
 		// Then check for repeats in the position
 		int pos = resistanceHeightMap[which].position;
 		for (int i = 0; i < getNumResistanceElements(); i++) {
-			if (resistanceHeightMap[i].position == pos) {
+			if (which != i && resistanceHeightMap[i].position == pos) {
 				setOfSources[resistanceHeightMap[i].index].changeResistanceWatts(watts);
 			}
 		}
@@ -2064,7 +2064,7 @@ double HPWH::getResistanceCapacity(int which /*=-1*/, UNITS pwrUnit /*=UNITS_KW*
 		// Then check for repeats in the position
 		int pos = resistanceHeightMap[which].position;
 		for (int i = 0; i < getNumResistanceElements(); i++) {
-			if (resistanceHeightMap[i].position == pos) {
+			if (which != i && resistanceHeightMap[i].position == pos) {
 				returnPower += setOfSources[resistanceHeightMap[i].index].perfMap[0].inputPower_coeffs[0];
 			}
 		}

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -492,6 +492,9 @@ class HPWH {
 	int getNumHeatSources() const;
 	/**< returns the number of heat sources  */
 
+	int getNumResistanceElements() const;
+	/**< returns the number of resistance elements  */
+
 	int getCompressorIndex() const;
 	/**< returns the index of the compressor in the heat source array.
 	Note only supports HPWHs with one compressor, if multiple will return the last index 
@@ -512,17 +515,29 @@ class HPWH {
 	int setScaleHPWHCapacityCOP(double scaleCapacity = 1., double scaleCOP = 1.);
 	/**< Scales the heatpump water heater input capacity and COP*/
 	
-	int setResistanceCapacity(double power, int which = 0, UNITS pwrUNIT = UNITS_KW);
-	// Scale the resistance elements in the heat source list. Which heat source is chosen is changes is given by which
-	// If which (0) changes all the resisistance elements in the tank.
-	// If which (1) changes the lowest resistance element
-	// If which (2) changes the highest resistance element
+	int setResistanceCapacity(double power, int which = -1, UNITS pwrUNIT = UNITS_KW);
+	/**< Scale the resistance elements in the heat source list. Which heat source is chosen is changes is given by "which"
+	- If which (-1) sets all the resisistance elements in the tank.
+	- If which (0, 1, 2...) sets the resistance element in a low to high order. 
+	  So if there are 3 elements 0 is the bottom, 1 is the middle, and 2 is the top element, regardless of their order 
+	  in setOfSources. If the elements exist on at the same node then all of the elements are set.
 
-	double getResistanceCapacity(int which = 0, UNITS pwrUNIT = UNITS_KW);
-	// Returns the resistance elements capacity. Which heat source is chosen is changes is given by which
-	// If which (0) returns all the resisistance elements in the tank.
-	// If which (1) returns the lowest resistance element
-	// If which (2) returns the highest resistance element
+	The only valid values for which are between -1 and getNumResistanceElements()-1. Since which is defined as the 
+	by the ordered height of the resistance elements it cannot refer to a compressor.
+	*/
+
+	double getResistanceCapacity(int which = -1, UNITS pwrUNIT = UNITS_KW);
+	/**< Returns the resistance elements capacity. Which heat source is chosen is changes is given by "which"
+	- If which (-1) gets all the resisistance elements in the tank.
+	- If which (0, 1, 2...) sets the resistance element in a low to high order. 
+	  So if there are 3 elements 0 is the bottom, 1 is the middle, and 2 is the top element, regardless of their order 
+	  in setOfSources. If the elements exist on at the same node then all of the elements are set.
+
+	The only valid values for which are between -1 and getNumResistanceElements()-1. Since which is defined as the 
+	by the ordered height of the resistance elements it cannot refer to a compressor.
+	*/
+
+	int getResistancePosition(int elementIndex) const;
 
 	double getNthHeatSourceEnergyInput(int N, UNITS units = UNITS_KWH) const;
 	/**< returns the energy input to the Nth heat source, with the specified units
@@ -625,6 +640,9 @@ class HPWH {
   /**< a helper function to set constants for the UA and tank size*/
   void calcDerivedHeatingValues(); 
   /**< a helper for the helper, calculating condentropy and the lowest node*/
+  void mapResRelativePosToSetOfSources();
+  /**< a helper function for the inits, creating a mapping function for the position of the resistance elements
+  to their indexes in setOfSources. */
 
 
   int checkInputs();
@@ -764,6 +782,15 @@ class HPWH {
 
   bool doConduction;
   /**<  If and only if true will model conduction between the internal nodes of the tank  */
+
+  struct resPoint {
+	  int index;
+	  int position;
+  };
+  std::vector<resPoint> resistanceHeightMap;
+  /**< A map from index of an resistance element in setOfSources to position in the tank, its
+  is sorted by height from lowest to highest*/
+
 
 };  //end of HPWH class
 

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -137,12 +137,12 @@ class HPWH {
 	  MODELS_AWHSTier3Generic80 = 178, /**< Generic AWHS Tier 3 80 gallons*/
 
 	  MODELS_StorageTank = 180,  /**< Generic Tank without heaters */
+	  MODELS_TamScalable_SP = 190,	/** < HPWH input passed off a poor preforming SP model that has scalable input capacity and COP  */
 
 	  // Non-preset models
 	  MODELS_CustomFile = 200,      /**< HPWH parameters were input via file */
 	  MODELS_CustomResTank = 201,   /**< HPWH parameters were input via HPWHinit_resTank */
 	  MODELS_CustomResTankSwing = 202,   /**< HPWH parameters were input via HPWHinit_resTank */
-	  MODELS_TamScalable_SP = 203,	/** < HPWH input passed off a poor preforming SP model that has scalable input capacity and COP  */
 
 	  // Larger Colmac models in single pass configuration 
 	  MODELS_ColmacCxV_5_SP  = 210,	 /**<  Colmac CxA_5 external heat pump in Single Pass Mode  */
@@ -327,13 +327,15 @@ class HPWH {
    * is at the bottom, the upper element is at the top third.  The logics are also set
    * to standard setting, with upper as VIP activating when the top third is too cold.
    */
-  int HPWHinit_resSwingTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W, double tUse_C);
-  /**< This function will initialize a HPWH object to be a resistance Swing tank, a specific 
-  * loop tank that is in series with the primary system and the recirculation system.
+ 
+  int HPWHinit_commercialResTank(double tankVol, double upperPower_W, double lowerPower_W, MODELS resTankType);
+  /**< This function will initialize a HPWH object to be a large commercial resistance storage water heater.
+  * The UA is defaulted to meet the federal minimum standby losses based on the volume. 
   *
   * Several assumptions regarding the tank configuration are assumed: the lower element
-  * is at the bottom, the upper element is at the top third.  The logics are also set
-  * to make sense for a swing tank which controls the elements off the top section of the tank.
+  * is at the bottom, the upper element is at the top third.
+  * 
+  * resTankType's types support thus far are swingtank. 
   */
 
   int HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double resUse_C);

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -142,7 +142,8 @@ class HPWH {
 	  // Non-preset models
 	  MODELS_CustomFile = 200,      /**< HPWH parameters were input via file */
 	  MODELS_CustomResTank = 201,   /**< HPWH parameters were input via HPWHinit_resTank */
-	  MODELS_CustomResTankSwing = 202,   /**< HPWH parameters were input via HPWHinit_resTank */
+	  MODELS_CustomComResTank = 202,   /**< HPWH parameters were input via HPWHinit_commercialResTank */
+	  MODELS_CustomComResTankSwing = 203,   /**< HPWH parameters were input via HPWHinit_commercialResTank, specific swing tank controls */
 
 	  // Larger Colmac models in single pass configuration 
 	  MODELS_ColmacCxV_5_SP  = 210,	 /**<  Colmac CxA_5 external heat pump in Single Pass Mode  */
@@ -335,7 +336,7 @@ class HPWH {
   * Several assumptions regarding the tank configuration are assumed: the lower element
   * is at the bottom, the upper element is at the top third.
   * 
-  * resTankType's types support thus far are swingtank. 
+  * resTankType's types support thus far are MODELS_CustomComResTank, MODELS_CustomComResSwingTank. 
   */
 
   int HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double resUse_C);

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -124,35 +124,163 @@ int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPo
 	return 0;  //successful init returns 0
 }
 
-int HPWH::HPWHinit_resSwingTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W, double tUse_C) {
-	double deadband_C = dF_TO_dC(8.);
-	if (tUse_C < 0. || tUse_C >(100. - deadband_C)) {
+//int HPWH::HPWHinit_resSwingTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W, double tUse_C) {
+//	double deadband_C = dF_TO_dC(8.);
+//	if (tUse_C < 0. || tUse_C >(100. - deadband_C)) {
+//		if (hpwhVerbosity >= VRB_reluctant) {
+//			msg("Use temperature is out of bounds, must be between 0 and 100 C.\n");
+//		}
+//		return HPWH_ABORT;
+//	}
+//
+//	// Create normal restank
+//	if (this->HPWHinit_resTank(tankVol_L, energyFactor, upperPower_W, lowerPower_W) == HPWH_ABORT) {
+//		return HPWH_ABORT;
+//	}
+//
+//	setpoint_C = tUse_C + deadband_C + dF_TO_dC(1);
+//	//start tank off at setpoint
+//	resetTankToSetpoint();
+//	hpwhModel = MODELS_CustomResTankSwing;
+//
+//	//Have to change control logic though. 
+//	for (int i = 0; i < numHeatSources; i++) {
+//		setOfSources[i].clearAllLogic(); // clear logic conditions for heat source
+//		setOfSources[i].addTurnOnLogic(HPWH::topThird(deadband_C)); // replace with swing tank logic 
+//	}
+//	if (upperPower_W > 0.) {
+//		setOfSources[0].companionHeatSource = &setOfSources[1];
+//	}
+//	// Recheck the heater is still valid
+//	// calculate oft-used derived values
+//	calcDerivedValues();
+//
+//	if (checkInputs() == HPWH_ABORT) return HPWH_ABORT;
+//
+//	isHeating = false;
+//	for (int i = 0; i < numHeatSources; i++) {
+//		if (setOfSources[i].isOn) {
+//			isHeating = true;
+//		}
+//		setOfSources[i].sortPerformanceMap();
+//	}
+//
+//	if (hpwhVerbosity >= VRB_emetic) {
+//		for (int i = 0; i < numHeatSources; i++) {
+//			msg("heat source %d: %p \n", i, &setOfSources[i]);
+//		}
+//		msg("\n\n");
+//	}
+//
+//	simHasFailed = false;
+//	return 0;  //successful init returns 0
+//}
+
+
+int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, double lowerPower_W, MODELS resTankType) {
+
+	setAllDefaults(); // reset all defaults if you're re-initilizing
+	// sets simHasFailed = true; this gets cleared on successful completion of init
+	// return 0 on success, HPWH_ABORT for failure
+
+	//low power element will cause divide by zero/negative UA in EF -> UA conversion
+	if (lowerPower_W < 0) {
 		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("Use temperature is out of bounds, must be between 0 and 100 C.\n");
+			msg("Lower resistance tank wattage below 0 W.  DOES NOT COMPUTE\n");
+		}
+		return HPWH_ABORT;
+	}
+	if (upperPower_W < 0.) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Upper resistance tank wattage below 0 W.  DOES NOT COMPUTE\n");
+		}
+		return HPWH_ABORT;
+	}
+	if (resTankType < MODELS_CustomResTank || resTankType > MODELS_CustomResTankSwing) {// if resTankType not supported here
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Resistance Tank Type not supported here");
 		}
 		return HPWH_ABORT;
 	}
 
-	// Create normal restank
-	if (this->HPWHinit_resTank(tankVol_L, energyFactor, upperPower_W, lowerPower_W) == HPWH_ABORT) {
+	//set tank size function has bounds checking
+	tankSizeFixed = false;
+	if (this->setTankSize(tankVol_L) == HPWH_ABORT) {
 		return HPWH_ABORT;
 	}
+	canScale = true;
 
-	setpoint_C = tUse_C + deadband_C + dF_TO_dC(1);
-	//start tank off at setpoint
-	resetTankToSetpoint();
-	hpwhModel = MODELS_CustomResTankSwing;
+	numNodes = 12;
+	tankTemps_C = new double[numNodes];
+	setpoint_C = F_TO_C(127.0);
+	resetTankToSetpoint(); //start tank off at setpoint
 
-	//Have to change control logic though. 
-	for (int i = 0; i < numHeatSources; i++) {
-		setOfSources[i].clearAllLogic(); // clear logic conditions for heat source
-		setOfSources[i].addTurnOnLogic(HPWH::topThird(deadband_C)); // replace with swing tank logic 
-	}
+	nextTankTemps_C = new double[numNodes];
+	doTempDepression = false;
+	tankMixesOnDraw = true;
+
+	// Count up heat sources
+	numHeatSources = 0;
+	numHeatSources += upperPower_W > 0. ? 1 : 0;
+	numHeatSources += lowerPower_W > 0. ? 1 : 0;
+	setOfSources = new HeatSource[numHeatSources];
+
+	// Deal with upper element
 	if (upperPower_W > 0.) {
-		setOfSources[0].companionHeatSource = &setOfSources[1];
+		// Only add an upper element when the upperPower_W > 0 otherwise ignore this.
+		// If the element is added this can mess with the intended logic.
+		HeatSource resistiveElementTop(this);
+		resistiveElementTop.setupAsResistiveElement(8, upperPower_W);
+		resistiveElementTop.addTurnOnLogic(HPWH::topThird(dF_TO_dC(20)));
+		resistiveElementTop.isVIP = true;
+
+		// Upper should always be first in setOfSources if it exists.
+		setOfSources[0] = resistiveElementTop; 
 	}
-	// Recheck the heater is still valid
-	// calculate oft-used derived values
+	
+	// Deal with bottom element
+	if (lowerPower_W > 0.) {
+		HeatSource resistiveElementBottom(this);
+		resistiveElementBottom.setupAsResistiveElement(0, lowerPower_W);
+
+		if (resTankType == MODELS_CustomResTank) {
+			//standard logic conditions
+			resistiveElementBottom.addTurnOnLogic(HPWH::bottomThird(dF_TO_dC(40.)));
+			resistiveElementBottom.addTurnOnLogic(HPWH::standby(dF_TO_dC(10.)));
+		}
+		else if (resTankType == MODELS_CustomResTankSwing) {
+			//swing tank logic
+			resistiveElementBottom.addTurnOnLogic(HPWH::topThird(8.)); // replace with swing tank logic
+		}
+
+		// set everything in it's correct place
+		if (numHeatSources == 1) {// if one only one slot
+			setOfSources[0] = resistiveElementBottom;
+		}
+		else if (numHeatSources == 2) { // if two upper already exists
+			setOfSources[1] = resistiveElementBottom;
+			setOfSources[0].followedByHeatSource = &setOfSources[1];
+		}
+	}
+
+	// Calc UA
+	// S <= .3 + 27/ Vm (%/hr) 
+	// SL = S(%/h)/100 * 8.25 (BTU/galF) * Vm (gal) * (140 – 75) (F)
+	// SL = UA deltaT. So deltaT actually cancels. 
+	// UA (BTU/hr/F) = 8.25 (BTU/galF) * (.3 + 27/Vm)(%/hr)/100 * Vm = 8.25 * (.3*Vm + 27 [G]) / 100, where 8.25 is actually 
+	double S = (.3 + 27. / GAL_TO_L(tankVol_L));
+	tankUA_kJperHrC = CPWATER_kJperkgC * DENSITYWATER_kgperL * S / 100. * tankVol_L; // Note (.3+27./GAL_TO_L(tankVol_L)) is unitless
+
+	if (tankUA_kJperHrC < 0.) {
+		if (hpwhVerbosity >= VRB_reluctant && tankUA_kJperHrC < -0.1) {
+			msg("Computed tankUA_kJperHrC is less than 0, and is reset to 0.");
+		}
+		tankUA_kJperHrC = 0.0;
+	}
+
+	hpwhModel = resTankType;
+
+	//calculate oft-used derived values
 	calcDerivedValues();
 
 	if (checkInputs() == HPWH_ABORT) return HPWH_ABORT;

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -124,58 +124,6 @@ int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPo
 	return 0;  //successful init returns 0
 }
 
-//int HPWH::HPWHinit_resSwingTank(double tankVol_L, double energyFactor, double upperPower_W, double lowerPower_W, double tUse_C) {
-//	double deadband_C = dF_TO_dC(8.);
-//	if (tUse_C < 0. || tUse_C >(100. - deadband_C)) {
-//		if (hpwhVerbosity >= VRB_reluctant) {
-//			msg("Use temperature is out of bounds, must be between 0 and 100 C.\n");
-//		}
-//		return HPWH_ABORT;
-//	}
-//
-//	// Create normal restank
-//	if (this->HPWHinit_resTank(tankVol_L, energyFactor, upperPower_W, lowerPower_W) == HPWH_ABORT) {
-//		return HPWH_ABORT;
-//	}
-//
-//	setpoint_C = tUse_C + deadband_C + dF_TO_dC(1);
-//	//start tank off at setpoint
-//	resetTankToSetpoint();
-//	hpwhModel = MODELS_CustomResTankSwing;
-//
-//	//Have to change control logic though. 
-//	for (int i = 0; i < numHeatSources; i++) {
-//		setOfSources[i].clearAllLogic(); // clear logic conditions for heat source
-//		setOfSources[i].addTurnOnLogic(HPWH::topThird(deadband_C)); // replace with swing tank logic 
-//	}
-//	if (upperPower_W > 0.) {
-//		setOfSources[0].companionHeatSource = &setOfSources[1];
-//	}
-//	// Recheck the heater is still valid
-//	// calculate oft-used derived values
-//	calcDerivedValues();
-//
-//	if (checkInputs() == HPWH_ABORT) return HPWH_ABORT;
-//
-//	isHeating = false;
-//	for (int i = 0; i < numHeatSources; i++) {
-//		if (setOfSources[i].isOn) {
-//			isHeating = true;
-//		}
-//		setOfSources[i].sortPerformanceMap();
-//	}
-//
-//	if (hpwhVerbosity >= VRB_emetic) {
-//		for (int i = 0; i < numHeatSources; i++) {
-//			msg("heat source %d: %p \n", i, &setOfSources[i]);
-//		}
-//		msg("\n\n");
-//	}
-//
-//	simHasFailed = false;
-//	return 0;  //successful init returns 0
-//}
-
 
 int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, double lowerPower_W, MODELS resTankType) {
 
@@ -268,8 +216,8 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 	// SL = S(%/h)/100 * 8.25 (BTU/galF) * Vm (gal) * (140 – 75) (F)
 	// SL = UA deltaT. So deltaT actually cancels. 
 	// UA (BTU/hr/F) = 8.25 (BTU/galF) * (.3 + 27/Vm)(%/hr)/100 * Vm = 8.25 * (.3*Vm + 27 [G]) / 100, where 8.25 is actually 
-	double S = (.3 + 27. / GAL_TO_L(tankVol_L));
-	tankUA_kJperHrC = CPWATER_kJperkgC * DENSITYWATER_kgperL * S / 100. * tankVol_L; // Note (.3+27./GAL_TO_L(tankVol_L)) is unitless
+	double S_PercperHr= (.3 + 27. / GAL_TO_L(tankVol_L));
+	tankUA_kJperHrC = CPWATER_kJperkgC * DENSITYWATER_kgperL * S_PercperHr / 100. * tankVol_L; // Note (.3+27./GAL_TO_L(tankVol_L)) is unitless
 
 	if (tankUA_kJperHrC < 0.) {
 		if (hpwhVerbosity >= VRB_reluctant && tankUA_kJperHrC < -0.1) {

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -144,7 +144,7 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 		}
 		return HPWH_ABORT;
 	}
-	if (resTankType < MODELS_CustomResTank || resTankType > MODELS_CustomResTankSwing) {// if resTankType not supported here
+	if (resTankType < MODELS_CustomComResTank || resTankType > MODELS_CustomComResTankSwing) {// if resTankType not supported here
 		if (hpwhVerbosity >= VRB_reluctant) {
 			msg("Resistance Tank Type not supported here");
 		}
@@ -191,12 +191,12 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 		HeatSource resistiveElementBottom(this);
 		resistiveElementBottom.setupAsResistiveElement(0, lowerPower_W);
 
-		if (resTankType == MODELS_CustomResTank) {
+		if (resTankType == MODELS_CustomComResTank) {
 			//standard logic conditions
 			resistiveElementBottom.addTurnOnLogic(HPWH::bottomThird(dF_TO_dC(40.)));
 			resistiveElementBottom.addTurnOnLogic(HPWH::standby(dF_TO_dC(10.)));
 		}
-		else if (resTankType == MODELS_CustomResTankSwing) {
+		else if (resTankType == MODELS_CustomComResTankSwing) {
 			//swing tank logic
 			resistiveElementBottom.addTurnOnLogic(HPWH::topThird(8.)); // replace with swing tank logic
 		}
@@ -216,8 +216,8 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 	// SL = S(%/h)/100 * 8.25 (BTU/galF) * Vm (gal) * (140 – 75) (F)
 	// SL = UA deltaT. So deltaT actually cancels. 
 	// UA (BTU/hr/F) = 8.25 (BTU/galF) * (.3 + 27/Vm)(%/hr)/100 * Vm = 8.25 * (.3*Vm + 27 [G]) / 100, where 8.25 is actually 
-	double S_PercperHr= (.3 + 27. / GAL_TO_L(tankVol_L));
-	tankUA_kJperHrC = CPWATER_kJperkgC * DENSITYWATER_kgperL * S_PercperHr / 100. * tankVol_L; // Note (.3+27./GAL_TO_L(tankVol_L)) is unitless
+	double S_PercperHr= (.3 + 27. / L_TO_GAL(tankVol_L));
+	tankUA_kJperHrC = CPWATER_kJperkgC * DENSITYWATER_kgperL * S_PercperHr / 100. * tankVol_L; // Note (.3+27./L_TO_GAL(tankVol_L)) has units %/hr
 
 	if (tankUA_kJperHrC < 0.) {
 		if (hpwhVerbosity >= VRB_reluctant && tankUA_kJperHrC < -0.1) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,12 +6,14 @@ add_executable(testTankSizeFixed testTankSizeFixed.cc)
 add_executable(testScaleHPWH testScaleHPWH.cc)
 add_executable(testMaxSetpoint testMaxSetpoint.cc)
 add_executable(testSizingFractions testSizingFractions.cc)
+add_executable(testResistanceFcts testResistanceFcts.cc)
 
 target_link_libraries(testTool libHPWHsim)
 target_link_libraries(testTankSizeFixed libHPWHsim)
 target_link_libraries(testScaleHPWH libHPWHsim)
 target_link_libraries(testMaxSetpoint libHPWHsim)
 target_link_libraries(testSizingFractions libHPWHsim)
+target_link_libraries(testResistanceFcts libHPWHsim)
 
 # Add output directory for test results
 add_custom_target(results_directory ALL COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/output")
@@ -24,6 +26,7 @@ add_test(NAME "Ready.Output.Files" COMMAND ${CMAKE_COMMAND} -E remove "${CMAKE_C
 add_test(NAME "testScaleHPWH" COMMAND  $<TARGET_FILE:testScaleHPWH> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME "testMaxSetpoint" COMMAND  $<TARGET_FILE:testMaxSetpoint> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 add_test(NAME "testSizingFractions" COMMAND  $<TARGET_FILE:testSizingFractions> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME "testResistanceFcts" COMMAND  $<TARGET_FILE:testResistanceFcts> ${testArgs} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 
 #add_test(NAME "testREGoesTo99C.AOSmithCAHP120" COMMAND $<TARGET_FILE:testTool> "Preset" "AOSmithCAHP120" "testREGoesTo99C"

--- a/test/testResistanceFcts.cc
+++ b/test/testResistanceFcts.cc
@@ -1,0 +1,184 @@
+
+
+/*unit test for isTankSizeFixed() functionality
+ *
+ *
+ *
+ */
+#include "HPWH.hh"
+#include "testUtilityFcts.cc"
+
+#include <iostream>
+#include <string> 
+
+using std::cout;
+using std::string;
+
+
+void testSetResistanceCapacityErrorChecks() {
+	HPWH hpwhHP1, hpwhR;
+	string input = "ColmacCxA_30_SP";
+
+	// get preset model 
+	getHPWHObject(hpwhHP1, input);
+
+	ASSERTTRUE(hpwhHP1.setResistanceCapacity(100.) == HPWH::HPWH_ABORT); // Need's to be scalable
+
+	input = "restankRealistic";
+	// get preset model 
+	getHPWHObject(hpwhR, input);
+	ASSERTTRUE(hpwhR.setResistanceCapacity(-100.) == HPWH::HPWH_ABORT); 
+	ASSERTTRUE(hpwhR.setResistanceCapacity(100., 3) == HPWH::HPWH_ABORT);
+	ASSERTTRUE(hpwhR.setResistanceCapacity(100., 30000) == HPWH::HPWH_ABORT);
+	ASSERTTRUE(hpwhR.setResistanceCapacity(100., -3) == HPWH::HPWH_ABORT);
+	ASSERTTRUE(hpwhR.setResistanceCapacity(100., 0, HPWH::UNITS_F) == HPWH::HPWH_ABORT);
+}
+
+void testGetSetResistanceErrors() {
+	HPWH hpwh;	
+	double lowerElementPower_W = 1000;
+	double lowerElementPower = lowerElementPower_W / 1000;
+	hpwh.HPWHinit_resTank(100., 0.95, 0., lowerElementPower_W);
+
+	double returnVal;
+	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW); // lower
+	ASSERTTRUE(relcmpd(returnVal, lowerElementPower));
+	returnVal = hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW); // both,
+	ASSERTTRUE(relcmpd(returnVal, lowerElementPower));
+	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW); // higher doesn't exist
+	ASSERTTRUE(returnVal == HPWH::HPWH_ABORT);
+}
+
+void testCommercialTankInitErrors() {
+	HPWH hpwh;
+	// init model 
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(-800., 100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative volume
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., -100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., -100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_restankRealistic) == HPWH::HPWH_ABORT); // non custom restank
+}
+
+void testGetNumResistanceElements() {
+	HPWH hpwh;
+
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 2); // Check 2 elements
+}
+
+void testGetResistancePositionInRETank() {
+	HPWH hpwh;
+
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 0); // Check lower element is there 
+	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no element
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no element
+
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
+	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no elements
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no elements
+
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
+	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check lower element is there 
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check 0 elements}
+}
+
+void testGetResistancePositionInCompressorTank() {
+	HPWH hpwh;
+
+	string input = "TamScalable_SP";
+	// get preset model 
+	getHPWHObject(hpwh, input);
+
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 9); // Check top elements
+	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check bottom elements
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check compressor isn't RE
+	ASSERTTRUE(hpwh.getResistancePosition(-1) == HPWH::HPWH_ABORT); // Check out of bounds
+	ASSERTTRUE(hpwh.getResistancePosition(1000) == HPWH::HPWH_ABORT); // Check out of bounds
+}
+
+void testCommercialTankErrorsWithBottomElement() {
+	HPWH hpwh;
+	double elementPower_kW = 10.; //KW
+	// init model 
+	hpwh.HPWHinit_commercialResTank(800., 0., elementPower_kW * 1000., HPWH::MODELS_CustomResTank);
+
+	// Check only lowest setting works
+	double factor = 3.;
+	// set both, but really only one
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, -1, HPWH::UNITS_KW) == 0); // Check sets
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
+	ASSERTTRUE(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // only have one element
+
+	// set lowest
+	factor = 4.;
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 0, HPWH::UNITS_KW) == 0); // Set just bottom
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
+	ASSERTTRUE(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // only have one element
+
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // set top returns error
+}
+void testCommercialTankErrorsWithTopElement() {
+	HPWH hpwh;
+	double elementPower_kW = 10.; //KW
+	// init model 
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., 0., HPWH::MODELS_CustomResTank);
+
+	// Check only bottom setting works
+	double factor = 3.;
+	// set both, but only bottom really.
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, -1, HPWH::UNITS_KW) == 0); // Check sets
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom which is now top with both
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check the lower and only element
+	ASSERTTRUE(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); //  error on non existant element
+
+	// set top
+	factor = 4.;
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 0, HPWH::UNITS_KW) == 0); // only one element to set 
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom which is now top with both
+	ASSERTTRUE(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // error on non existant bottom
+
+	// set bottom returns error
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT);
+}
+
+void testCommercialTankInit() {
+	HPWH hpwh;
+	double elementPower_kW = 10.; //KW
+	// init model 
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomResTank);
+
+}
+
+int main(int argc, char *argv[])
+{
+
+
+	testSetResistanceCapacityErrorChecks(); // Check the resistance reset throws errors when expected.
+
+	testGetSetResistanceErrors(); // Check can make ER residential tank with one lower element, and can't set/get upper
+
+	// Should move these to a seperate build later.
+	testCommercialTankInitErrors(); // test it inits as expected
+	testGetNumResistanceElements(); // unit test on getNumResistanceElements()
+	testGetResistancePositionInRETank(); // unit test on getResistancePosition() for an RE tank
+	testGetResistancePositionInCompressorTank(); // unit test on getResistancePosition() for a compressor
+
+	testCommercialTankErrorsWithBottomElement(); // 
+	testCommercialTankErrorsWithTopElement();
+	testCommercialTankInit(); // 
+
+	//Made it through the gauntlet
+	return 0;
+}

--- a/test/testResistanceFcts.cc
+++ b/test/testResistanceFcts.cc
@@ -52,41 +52,42 @@ void testGetSetResistanceErrors() {
 void testCommercialTankInitErrors() {
 	HPWH hpwh;
 	// init model 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(-800., 100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative volume
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., -100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative element
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., -100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(-800., 100., 100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative volume
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., -100., 100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., -100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // non commercial restank
 	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_restankRealistic) == HPWH::HPWH_ABORT); // non custom restank
 }
 
 void testGetNumResistanceElements() {
 	HPWH hpwh;
 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // Check needs one element
 
-	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
-	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
-	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 2); // Check 2 elements
 }
 
 void testGetResistancePositionInRETank() {
 	HPWH hpwh;
 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // Check needs one element
 
-	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 0); // Check lower element is there 
 	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no element
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no element
 
-	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
 	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no elements
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no elements
 
-	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomComResTank);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
 	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check lower element is there 
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check 0 elements}
@@ -110,7 +111,7 @@ void testCommercialTankErrorsWithBottomElement() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	// init model 
-	hpwh.HPWHinit_commercialResTank(800., 0., elementPower_kW * 1000., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., 0., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
 
 	// Check only lowest setting works
 	double factor = 3.;
@@ -133,7 +134,7 @@ void testCommercialTankErrorsWithTopElement() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	// init model 
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., 0., HPWH::MODELS_CustomResTank);
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., 0., HPWH::MODELS_CustomComResTank);
 
 	// Check only bottom setting works
 	double factor = 3.;
@@ -156,9 +157,48 @@ void testCommercialTankErrorsWithTopElement() {
 void testCommercialTankInit() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
-	// init model 
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomResTank);
+	double UA;
+	double UA800 = 14.232692;
+	double UA2 = 4.275807;
+	double UA50 = 4.874717;
+	double UA200 = 6.7463127;
+	double UA2000 = 29.2054531;
+	double UA20000 = 253.7968561;
 
+	// Check UA is as expected at 800 gal
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA800));
+	// Check UA independent of elements
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW, elementPower_kW, HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA800));
+	// Check UA independent of model
+	hpwh.HPWHinit_commercialResTank(800., elementPower_kW, elementPower_kW, HPWH::MODELS_CustomComResTankSwing);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA800));
+
+
+	// Check UA is as expected at 2 gal
+	hpwh.HPWHinit_commercialResTank(2., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA2));
+	// Check UA is as expected at 50 gal
+	hpwh.HPWHinit_commercialResTank(50., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA50));
+	// Check UA is as expected at 200 gal
+	hpwh.HPWHinit_commercialResTank(200., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA200));
+	// Check UA is as expected at 2000 gal
+	hpwh.HPWHinit_commercialResTank(2000., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA2000));
+	// Check UA is as expected at 20000 gal
+	hpwh.HPWHinit_commercialResTank(20000., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, UA20000));
 }
 
 int main(int argc, char *argv[])

--- a/test/testScaleHPWH.cc
+++ b/test/testScaleHPWH.cc
@@ -397,11 +397,11 @@ void testResistanceScales() {
 	getHPWHObject(hpwh, input);
 
 	double returnVal;
+	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
+	ASSERTTRUE(relcmpd(returnVal, elementPower));
 	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW);
 	ASSERTTRUE(relcmpd(returnVal, elementPower));
-	returnVal = hpwh.getResistanceCapacity(2, HPWH::UNITS_KW);
-	ASSERTTRUE(relcmpd(returnVal, elementPower));
-	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
+	returnVal = hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW);
 	ASSERTTRUE(relcmpd(returnVal, 2.*elementPower));
 
 	// check units convert
@@ -411,21 +411,21 @@ void testResistanceScales() {
 	// Check setting one works
 	double factor = 2.0;
 	hpwh.setResistanceCapacity(factor * elementPower, 1);
-	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW);
-	ASSERTTRUE(relcmpd(returnVal, factor * elementPower));
-	returnVal = hpwh.getResistanceCapacity(2, HPWH::UNITS_KW);
-	ASSERTTRUE(relcmpd(returnVal, elementPower));
 	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
+	ASSERTTRUE(relcmpd(returnVal, factor * elementPower));
+	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW);
+	ASSERTTRUE(relcmpd(returnVal, elementPower));
+	returnVal = hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW);
 	ASSERTTRUE(relcmpd(returnVal, factor * elementPower + elementPower));
 
 	// Check setting both works
 	factor = 3.;
 	hpwh.setResistanceCapacity(factor * elementPower, 0);
+	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
+	ASSERTTRUE(relcmpd(returnVal, factor * elementPower));
 	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW);
 	ASSERTTRUE(relcmpd(returnVal, factor * elementPower));
-	returnVal = hpwh.getResistanceCapacity(2, HPWH::UNITS_KW);
-	ASSERTTRUE(relcmpd(returnVal, factor * elementPower));
-	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
+	returnVal = hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW);
 	ASSERTTRUE(relcmpd(returnVal, 2.*factor * elementPower));
 }
 
@@ -435,33 +435,16 @@ void testGetSetResistanceErrors() {
 	double lowerElementPower = lowerElementPower_W / 1000;
 	hpwh.HPWHinit_resTank(100., 0.95, 0., lowerElementPower_W);
 
+	hpwh.HPWHinit_resTank(100., 0.95, 0., lowerElementPower_W);
+
 	double returnVal;
 	returnVal = hpwh.getResistanceCapacity(1, HPWH::UNITS_KW); // lower
 	ASSERTTRUE(relcmpd(returnVal, lowerElementPower));
-	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW); // both, really only lower
+	returnVal = hpwh.getResistanceCapacity(-1, HPWH::UNITS_KW); // both,
 	ASSERTTRUE(relcmpd(returnVal, lowerElementPower));
-	returnVal = hpwh.getResistanceCapacity(2, HPWH::UNITS_KW); // error on non existant upper
-	ASSERTTRUE(returnVal == HPWH::HPWH_ABORT);
-
-	// Switch to commercial res tank here later
-	//// Check only bottom setting works
-	//double factor = 3.;
-	//// set both, but only bottom really.
-	//ASSERTTRUE(hpwh.setResistanceCapacity(factor * lowerElementPower, 0, HPWH::UNITS_KW) == 0);
-	//returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
-	//ASSERTTRUE(relcmpd(returnVal, factor * lowerElementPower));
-	//
-	//// set bottom
-	//factor = 4.;
-	//ASSERTTRUE(hpwh.setResistanceCapacity(factor * lowerElementPower, 1, HPWH::UNITS_KW) == 0);
-	//returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW);
-	//ASSERTTRUE(relcmpd(returnVal, factor * lowerElementPower));
-	//
-	//// set top returns error
-	//ASSERTTRUE(hpwh.setResistanceCapacity(factor * lowerElementPower, 2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT);
-
+	returnVal = hpwh.getResistanceCapacity(0, HPWH::UNITS_KW); // highest is lowest
+	ASSERTTRUE(relcmpd(returnVal, lowerElementPower));
 }
-
 
 void testStorageTankErrors() {
 	HPWH hpwh;
@@ -473,7 +456,8 @@ void testStorageTankErrors() {
 	ASSERTTRUE(hpwh.setScaleHPWHCapacityCOP(1., 1.) == HPWH::HPWH_ABORT);
 
 }
-
+//////////////////////////////////////////////////////////////////////////////////////////
+// should move these tests to seperate test script.
 void testCommercialTankInitErrors() {
 	HPWH hpwh;
 	// init model 
@@ -483,29 +467,84 @@ void testCommercialTankInitErrors() {
 	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., -100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // negative element
 	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_restankRealistic) == HPWH::HPWH_ABORT); // non custom restank
 }
+
+void testGetNumResistanceElements() {
+	HPWH hpwh;
+
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getNumResistanceElements() == 2); // Check 2 elements
+}
+
+void testGetResistancePositionInRETank() {
+	HPWH hpwh;
+
+	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // Check needs one element
+
+	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 0); // Check lower element is there 
+	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no element
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no element
+
+	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
+	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no elements
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no elements
+
+	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomResTank);
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
+	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check lower element is there 
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check 0 elements}
+}
+
+void testGetResistancePositionInCompressorTank() {
+	HPWH hpwh;
+
+	string input = "TamScalable_SP";
+	// get preset model 
+	getHPWHObject(hpwh, input);
+
+	ASSERTTRUE(hpwh.getResistancePosition(0) == 9); // Check top elements
+	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check bottom elements
+	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check compressor isn't RE
+	ASSERTTRUE(hpwh.getResistancePosition(-1) == HPWH::HPWH_ABORT); // Check out of bounds
+	ASSERTTRUE(hpwh.getResistancePosition(1000) == HPWH::HPWH_ABORT); // Check out of bounds
+}
+
 void testCommercialTankErrorsWithBottomElement() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	// init model 
 	hpwh.HPWHinit_commercialResTank(800., 0., elementPower_kW * 1000., HPWH::MODELS_CustomResTank);
 
-	// Check only bottom setting works
+	// Check only lowest setting works
 	double factor = 3.;
-	// set both, but only bottom really.
+	// set both, but really only one
 	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 0, HPWH::UNITS_KW) == 0); // Check sets
 	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
 	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW), factor * elementPower_kW)); // highest is lowest
+
 	ASSERTTRUE(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // error on non existant upper
 
-	// set bottom
+	// set lowest
 	factor = 4.;
 	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 1, HPWH::UNITS_KW) == 0); // Set just bottom
 	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
 	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
-	ASSERTTRUE(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // error on non existant upper
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW), factor * elementPower_kW)); // highest is lowest
 
-	// set top returns error
-	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT);
+	//ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // set top returns error
+	// set highest
+	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 2, HPWH::UNITS_KW) == 0);  // highest is lowest
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW), factor * elementPower_kW)); // highest is lowest
 }
 void testCommercialTankErrorsWithTopElement() {
 	HPWH hpwh;
@@ -517,9 +556,9 @@ void testCommercialTankErrorsWithTopElement() {
 	double factor = 3.;
 	// set both, but only bottom really.
 	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 0, HPWH::UNITS_KW) == 0); // Check sets
-	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just top with both
-	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets top with top
-	ASSERTTRUE(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW) == HPWH::HPWH_ABORT); // error on non existant bottom
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(0, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets just bottom with both
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(1, HPWH::UNITS_KW), factor * elementPower_kW)); // Check gets bottom with bottom
+	ASSERTTRUE(relcmpd(hpwh.getResistanceCapacity(2, HPWH::UNITS_KW), factor * elementPower_kW)); // highest is lowest
 
 	// set top
 	factor = 4.;
@@ -540,9 +579,15 @@ void testCommercialTankInit() {
 
 }
 
-
 int main(int argc, char *argv[])
 {
+	// Should move these to a seperate build later.
+	testCommercialTankInitErrors(); // test it inits as expected
+	testGetNumResistanceElements(); // unit test on getNumResistanceElements()
+	testGetResistancePositionInRETank(); // unit test on getResistancePosition() for an RE tank
+	testGetResistancePositionInCompressorTank(); // unit test on getResistancePosition() for a compressor
+
+
 	testScalableHPWHScales(); // Test the scalable model scales properly
 
 	testNoScaleOutOfBounds(); // Test that models can't scale with invalid inputs 
@@ -570,7 +615,11 @@ int main(int argc, char *argv[])
 	testStorageTankErrors(); // Make sure we can't scale the storage tank.
 
 	// Should move these to a seperate build later.
-	testCommercialTankInitErrors(); //
+	testCommercialTankInitErrors(); // test it inits as expected
+	testGetNumResistanceElements(); // unit test on getNumResistanceElements()
+	testGetResistancePositionInRETank(); // unit test on getResistancePosition() for an RE tank
+	testGetResistancePositionInCompressorTank(); // unit test on getResistancePosition() for a compressor
+
 	testCommercialTankErrorsWithBottomElement(); // 
 	testCommercialTankErrorsWithTopElement();
 	testCommercialTankInit(); // 


### PR DESCRIPTION
  - HPWHinit_commercialResTank()
    - Separate MODELS_CustomComResTank and MODELS_CustomComResTankSwing to differentiate definition from MODELS_CustomResTank (which uses the EF residential definition)
  - getNumResistanceElements()
  - get/setResistanceCapacity now use an absolute "which" argument, which refers to the elements from lower to upper.  which = -1 gets/sets all the elements
    - if elements at same position will change all of them in that position.
    - which defaults to -1 to maintain behavior
- Testing of new functions