### PR TITLE
Increased API for Compressors

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -866,7 +866,7 @@ double HPWH::getMaxCompressorSetpoint(UNITS units /*=UNITS_C*/) const {
 		if (hpwhVerbosity >= VRB_reluctant) {
 			msg("Unit does not have a compressor \n");
 		}
-		return HPWH__ABORT;
+		return HPWH_ABORT;
 	}
 
 	double returnVal = setOfSources[compressorIndex].maxSetpoint_C;
@@ -880,9 +880,9 @@ double HPWH::getMaxCompressorSetpoint(UNITS units /*=UNITS_C*/) const {
 		if (hpwhVerbosity >= VRB_reluctant) {
 			msg("Incorrect unit specification for getMaxCompressorSetpoint. \n");
 		}
-		return HPWH__ABORT;
+		return HPWH_ABORT;
 	}
-	return returnVal
+	return returnVal;
 }
 
 bool HPWH::isNewSetpointPossible(double newSetpoint, double& maxAllowedSetpoint, string& why, UNITS units /*=UNITS_C*/) const {
@@ -1808,14 +1808,23 @@ double HPWH::getLocationTemp_C() const {
 int HPWH::getHPWHModel() const {
 	return hpwhModel;
 }
-int HPWH::getCoilConfig() const {
+int HPWH::getCompressorCoilConfig() const {
 	if (!hasACompressor()) {
 		if (hpwhVerbosity >= VRB_reluctant) {
 			msg("Current model does not have a compressor.  \n");
 		}
 		return HPWH_ABORT;
 	}
-	return setOfSources[compressorIndex].coilConfig;
+	return setOfSources[compressorIndex].configuration;
+}
+bool HPWH::isCompressorMultipass() const {
+	if (!hasACompressor()) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Current model does not have a compressor.  \n");
+		}
+		return HPWH_ABORT;
+	}
+	return setOfSources[compressorIndex].isMultipass;
 }
 
 bool HPWH::hasACompressor() const {
@@ -2457,7 +2466,7 @@ HPWH::HeatSource::HeatSource(HPWH *parentInput)
 	:hpwh(parentInput), isOn(false), lockedOut(false), doDefrost(false), backupHeatSource(NULL), companionHeatSource(NULL),
 	followedByHeatSource(NULL), minT(-273.15), maxT(100), hysteresis_dC(0), airflowFreedom(1.0), maxSetpoint_C(100.),
 	typeOfHeatSource(TYPE_none), extrapolationMethod(EXTRAP_LINEAR), maxOut_at_LowT{ 100, -273.15 }, standbyLogic(NULL),
-	heatingCycle(CYCLE_multipass)
+	isMultipass(true)
 {}
 
 HPWH::HeatSource::HeatSource(const HeatSource &hSource) {
@@ -2504,7 +2513,7 @@ HPWH::HeatSource::HeatSource(const HeatSource &hSource) {
 
 	configuration = hSource.configuration;
 	typeOfHeatSource = hSource.typeOfHeatSource;
-	heatingCycle = hSource.heatingCycle;
+	isMultipass = hSource.isMultipass;
 
 	lowestNode = hSource.lowestNode;
 
@@ -2564,7 +2573,7 @@ HPWH::HeatSource& HPWH::HeatSource::operator=(const HeatSource &hSource) {
 
 	configuration = hSource.configuration;
 	typeOfHeatSource = hSource.typeOfHeatSource;
-	heatingCycle = hSource.heatingCycle;
+	isMultipass = hSource.isMultipass;
 
 	lowestNode = hSource.lowestNode;
 	extrapolationMethod = hSource.extrapolationMethod;
@@ -3374,7 +3383,7 @@ double HPWH::HeatSource::addHeatExternal(double externalT_C, double minutesToRun
 			hpwh->msg("bottom tank temp: %.2lf \n", hpwh->tankTemps_C[0]);
 		}
 
-		if (heatingCycle == CYCLE_singlepass) {
+		if (!this->isMultipass) {
 			//how much heat is available this timestep
 			getCapacity(externalT_C, hpwh->tankTemps_C[0], inputTemp_BTUperHr, capTemp_BTUperHr, copTemp);
 			heatingCapacity_kJ = BTU_TO_KJ(capTemp_BTUperHr * (minutesToRun / 60.0));
@@ -4271,10 +4280,10 @@ int HPWH::HPWHinit_file(string configFile) {
 			else if (token == "heatCycle") {
 				line_ss >> tempString;
 				if (tempString == "singlepass") {
-					setOfSources[heatsource].heatingCycle = CYCLE_singlepass;
+					setOfSources[heatsource].isMultipass = false;
 				} 
 				else if (tempString == "multipass") {
-					setOfSources[heatsource].heatingCycle = CYCLE_multipass;
+					setOfSources[heatsource].isMultipass = true;
 				}
 				else {
 					if (hpwhVerbosity >= VRB_reluctant) {

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -860,6 +860,31 @@ double HPWH::getSetpoint(UNITS units /*=UNITS_C*/) const{
 	}
 }
 
+double HPWH::getMaxCompressorSetpoint(UNITS units /*=UNITS_C*/) const {
+	
+	if (!hasACompressor()) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Unit does not have a compressor \n");
+		}
+		return HPWH__ABORT;
+	}
+
+	double returnVal = setOfSources[compressorIndex].maxSetpoint_C;
+	if (units == UNITS_C) {
+		returnVal = returnVal;
+	}
+	else if (units == UNITS_F) {
+		returnVal = F_TO_C(returnVal);
+	}
+	else {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Incorrect unit specification for getMaxCompressorSetpoint. \n");
+		}
+		return HPWH__ABORT;
+	}
+	return returnVal
+}
+
 bool HPWH::isNewSetpointPossible(double newSetpoint, double& maxAllowedSetpoint, string& why, UNITS units /*=UNITS_C*/) const {
 	double newSetpoint_C;
 	double maxAllowedSetpoint_C = -273.15;
@@ -1782,6 +1807,15 @@ double HPWH::getLocationTemp_C() const {
 
 int HPWH::getHPWHModel() const {
 	return hpwhModel;
+}
+int HPWH::getCoilConfig() const {
+	if (!hasACompressor()) {
+		if (hpwhVerbosity >= VRB_reluctant) {
+			msg("Current model does not have a compressor.  \n");
+		}
+		return HPWH_ABORT;
+	}
+	return setOfSources[compressorIndex].coilConfig;
 }
 
 bool HPWH::hasACompressor() const {

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -33,11 +33,9 @@ class HPWH {
   static const float DENSITYWATER_kgperL;
   static const float KWATER_WpermC;
   static const float CPWATER_kJperkgC;
-  static const int CONDENSITY_SIZE = 12;  /**< this must be an integer, and only the value 12
-  //change at your own risk */
+  static const int CONDENSITY_SIZE = 12;  /**< this must be an integer, and only the value 12 change at your own risk */
   static const int MAXOUTSTRING = 200;  /**< this is the maximum length for a debuging output string */
-  static const float TOL_MINVALUE; /**< any amount of heat distribution less than this is reduced to 0
-  //this saves on computations */
+  static const float TOL_MINVALUE; /**< any amount of heat distribution less than this is reduced to 0 this saves on computations */
   static const float UNINITIALIZED_LOCATIONTEMP;  /**< this is used to tell the
   simulation when the location temperature has not been initialized */
   static const float ASPECTRATIO; /**< A constant to define the aspect ratio between the tank height and
@@ -137,7 +135,7 @@ class HPWH {
 	  MODELS_AWHSTier3Generic80 = 178, /**< Generic AWHS Tier 3 80 gallons*/
 
 	  MODELS_StorageTank = 180,  /**< Generic Tank without heaters */
-	  MODELS_TamScalable_SP = 190,	/** < HPWH input passed off a poor preforming SP model that has scalable input capacity and COP  */
+	  MODELS_TamScalable_SP = 190, /** < HPWH input passed off a poor preforming SP model that has scalable input capacity and COP  */
 
 	  // Non-preset models
 	  MODELS_CustomFile = 200,      /**< HPWH parameters were input via file */
@@ -146,7 +144,7 @@ class HPWH {
 	  MODELS_CustomComResTankSwing = 203,   /**< HPWH parameters were input via HPWHinit_commercialResTank, specific swing tank controls */
 
 	  // Larger Colmac models in single pass configuration 
-	  MODELS_ColmacCxV_5_SP  = 210,	 /**<  Colmac CxA_5 external heat pump in Single Pass Mode  */
+	  MODELS_ColmacCxV_5_SP  = 210,  /**<  Colmac CxA_5 external heat pump in Single Pass Mode  */
 	  MODELS_ColmacCxA_10_SP = 211,  /**<  Colmac CxA_10 external heat pump in Single Pass Mode */
 	  MODELS_ColmacCxA_15_SP = 212,  /**<  Colmac CxA_15 external heat pump in Single Pass Mode */
 	  MODELS_ColmacCxA_20_SP = 213,  /**<  Colmac CxA_20 external heat pump in Single Pass Mode */
@@ -162,7 +160,7 @@ class HPWH {
 	  MODELS_ColmacCxA_30_MP = 315,  /**<  Colmac CxA_30 external heat pump in Multi Pass Mode */
 	  
 	  // Larger Nyle models in single pass configuration
-	  MODELS_NyleC25A_SP = 230, /*< Nyle C25A external heat pump in Single Pass Mode  */
+	  MODELS_NyleC25A_SP = 230,  /*< Nyle C25A external heat pump in Single Pass Mode  */
 	  MODELS_NyleC60A_SP = 231,  /*< Nyle C60A external heat pump in Single Pass Mode  */
 	  MODELS_NyleC90A_SP = 232,  /*< Nyle C90A external heat pump in Single Pass Mode  */
 	  MODELS_NyleC125A_SP = 233, /*< Nyle C125A external heat pump in Single Pass Mode */
@@ -171,17 +169,17 @@ class HPWH {
 	  // Larger Nyle models with the cold weather package!
 	  MODELS_NyleC60A_C_SP  = 241,  /*< Nyle C60A external heat pump in Single Pass Mode  */
 	  MODELS_NyleC90A_C_SP  = 242,  /*< Nyle C90A external heat pump in Single Pass Mode  */
-	  MODELS_NyleC125A_C_SP = 243, /*< Nyle C125A external heat pump in Single Pass Mode */
-	  MODELS_NyleC185A_C_SP = 244, /*< Nyle C185A external heat pump in Single Pass Mode */
-	  MODELS_NyleC250A_C_SP = 245, /*< Nyle C250A external heat pump in Single Pass Mode */
+	  MODELS_NyleC125A_C_SP = 243,  /*< Nyle C125A external heat pump in Single Pass Mode */
+	  MODELS_NyleC185A_C_SP = 244,  /*< Nyle C185A external heat pump in Single Pass Mode */
+	  MODELS_NyleC250A_C_SP = 245,  /*< Nyle C250A external heat pump in Single Pass Mode */
 
 	  // Larger Nyle models in multi pass configuration
-	  MODELS_NyleC25A_MP  = 330, /*< Nyle C25A external heat pump in Multi Pass Mode  */
+	  MODELS_NyleC25A_MP  = 330,  /*< Nyle C25A external heat pump in Multi Pass Mode  */
 	  MODELS_NyleC60A_MP  = 331,  /*< Nyle C60A external heat pump in Multi Pass Mode  */
 	  MODELS_NyleC90A_MP  = 332,  /*< Nyle C90A external heat pump in Multi Pass Mode  */
-	  MODELS_NyleC125A_MP = 333, /*< Nyle C125A external heat pump in Multi Pass Mode */
-	  MODELS_NyleC185A_MP = 334, /*< Nyle C185A external heat pump in Multi Pass Mode */
-	  MODELS_NyleC250A_MP = 335  /*< Nyle C250A external heat pump in Multi Pass Mode */
+	  MODELS_NyleC125A_MP = 333,  /*< Nyle C125A external heat pump in Multi Pass Mode */
+	  MODELS_NyleC185A_MP = 334,  /*< Nyle C185A external heat pump in Multi Pass Mode */
+	  MODELS_NyleC250A_MP = 335   /*< Nyle C250A external heat pump in Multi Pass Mode */
     };
 
   ///specifies the modes for writing output
@@ -311,8 +309,7 @@ class HPWH {
 	 * This is useful for testing new variations, and for the sort of variability
 	 * that we typically do when creating SEEM runs
 	 * Appropriate use of this function can be found in the documentation
-   *
-   *
+    
 	 * The return value is 0 for successful initialization, HPWH_ABORT otherwise
 	 */
 
@@ -413,6 +410,10 @@ class HPWH {
 		is no compressor then checks that the new setpoint is less than boiling. The setpoint can be
 		set higher than the compressor max outlet temperature if there is a  backup resistance element, 
 		but the compressor will not operate above this temperature. maxAllowedSetpoint_C returns the */
+
+  double getMaxCompressorSetpoint(UNITS units = UNITS_C) const;
+  /**< a function to return the max operating temperature of the compressor which can be different than 
+	  the value returned in isNewSetpointPossible() if there are resistance elements. */
 
   double getMinOperatingTemp(UNITS units = UNITS_C) const;
   /**< a function to return the minimum operating temperature of the compressor  */
@@ -586,6 +587,8 @@ class HPWH {
 
   int getHPWHModel() const;
   /**< get the model number of the HPWHsim model number of the hpwh */
+
+  int getCoilConfig() const;
 
   bool hasACompressor() const;
 /**< Returns if the HPWH model has a compressor or not, could be a storage or resistance tank. */

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -215,12 +215,6 @@ class HPWH {
   };		  
 
   /** specifies the type of heat source  */
-  enum HEATING_CYCLE {
-	  CYCLE_singlepass,   /**< a seperated split system in single pass operating mode  */
-	  CYCLE_multipass		  /**< a unitary or split system in multi-pass operating mode*/
-  };
-
-  /** specifies the type of heat source  */
   enum HEATSOURCE_TYPE {
     TYPE_none,        /**< a default to check to make sure it's been set  */
     TYPE_resistance,  /**< a resistance element  */
@@ -588,7 +582,8 @@ class HPWH {
   int getHPWHModel() const;
   /**< get the model number of the HPWHsim model number of the hpwh */
 
-  int getCoilConfig() const;
+  int getCompressorCoilConfig() const;
+  bool isCompressorMultipass() const;
 
   bool hasACompressor() const;
 /**< Returns if the HPWH model has a compressor or not, could be a storage or resistance tank. */
@@ -1005,14 +1000,14 @@ class HPWH::HeatSource {
       cop (not capacity) for cases where the air flow is restricted - typically ducting */
 
 
-	COIL_CONFIG configuration; /**<  submerged, wrapped, external */
+  COIL_CONFIG configuration; /**<  submerged, wrapped, external */
   HEATSOURCE_TYPE typeOfHeatSource;  /**< compressor, resistance, extra, none */
-  HEATING_CYCLE heatingCycle; /**< single pass or multi-pass. Anything not obviously split system single pass is multipass*/
+  bool isMultipass; /**< single pass or multi-pass. Anything not obviously split system single pass is multipass*/
 
-	int lowestNode;
+  int lowestNode;
   /**< hold the number of the first non-zero condensity entry */
 
-	EXTRAP_METHOD extrapolationMethod; /**< linear or nearest neighbor*/
+  EXTRAP_METHOD extrapolationMethod; /**< linear or nearest neighbor*/
 
 
 

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -709,7 +709,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.maxT = F_TO_C(120.);
 		compressor.hysteresis_dC = 0;  //no hysteresis
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.maxSetpoint_C = MAXOUTLET_R134A;
 
 		compressor.addTurnOnLogic(HPWH::bottomThird(20));
@@ -992,7 +992,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.typeOfHeatSource = TYPE_compressor;
 		compressor.setCondensity(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.perfMap.reserve(1);
 		compressor.hysteresis_dC = 0;
 
@@ -1132,7 +1132,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.setCondensity(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 		compressor.extrapolationMethod = EXTRAP_NEAREST;
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.perfMap.reserve(1);
 
 		//logic conditions
@@ -1273,7 +1273,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.isOn = false;
 		compressor.isVIP = true;
 		compressor.typeOfHeatSource = TYPE_compressor;
-
+		compressor.minT = F_TO_C(-25.);
 		compressor.setCondensity(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 		compressor.perfMap.reserve(5);
@@ -1310,7 +1310,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 
 		compressor.hysteresis_dC = 4;
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.maxSetpoint_C = MAXOUTLET_R744;
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		//		No minT!
@@ -1356,7 +1356,8 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.isOn = false;
 		compressor.isVIP = true;
 		compressor.typeOfHeatSource = TYPE_compressor;
-		
+		compressor.minT = F_TO_C(-25.);
+
 		compressor.setCondensity(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 
 		compressor.perfMap.reserve(5);
@@ -1393,7 +1394,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 
 		compressor.hysteresis_dC = 4;
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.maxSetpoint_C = MAXOUTLET_R744;
 		///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 		//		No minT!
@@ -3136,7 +3137,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		compressor.typeOfHeatSource = TYPE_compressor;
 		compressor.setCondensity(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
 		compressor.configuration = HeatSource::CONFIG_EXTERNAL;
-		compressor.heatingCycle = CYCLE_singlepass;
+		compressor.isMultipass = false;
 		compressor.perfMap.reserve(1);
 		compressor.hysteresis_dC = 0;
 	

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(testScaleHPWH testScaleHPWH.cc)
 add_executable(testMaxSetpoint testMaxSetpoint.cc)
 add_executable(testSizingFractions testSizingFractions.cc)
 add_executable(testResistanceFcts testResistanceFcts.cc)
+add_executable(testCompressorFcts testCompressorFcts.cc)
 
 target_link_libraries(testTool libHPWHsim)
 target_link_libraries(testTankSizeFixed libHPWHsim)
@@ -14,6 +15,7 @@ target_link_libraries(testScaleHPWH libHPWHsim)
 target_link_libraries(testMaxSetpoint libHPWHsim)
 target_link_libraries(testSizingFractions libHPWHsim)
 target_link_libraries(testResistanceFcts libHPWHsim)
+target_link_libraries(testCompressorFcts libHPWHsim)
 
 # Add output directory for test results
 add_custom_target(results_directory ALL COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/output")

--- a/test/testCompressorFcts.cc
+++ b/test/testCompressorFcts.cc
@@ -1,0 +1,76 @@
+
+
+/*unit test for isTankSizeFixed() functionality
+ *
+ *
+ *
+ */
+#include "HPWH.hh"
+#include "testUtilityFcts.cc"
+
+#include <iostream>
+#include <string> 
+
+using std::cout;
+using std::string;
+
+
+
+void testHasACompressor(string input, bool expected) {
+	HPWH hpwh;
+	getHPWHObject(hpwh, input);	// get preset model 
+	ASSERTTRUE(hpwh.hasACompressor() == expected); 
+}
+
+void testGetCompCoilConfig(string input, int expected) {
+	HPWH hpwh;
+	getHPWHObject(hpwh, input);	// get preset model 
+	ASSERTTRUE(hpwh.getCompressorCoilConfig() == expected);
+}
+
+void testIsCompressorMultipass(string input, bool expected) {
+	HPWH hpwh;
+	getHPWHObject(hpwh, input);	// get preset model 
+	ASSERTTRUE(hpwh.isCompressorMultipass() == expected);
+}
+
+void testGetMaxCompressorSetpoint(string input, double expected) {
+	HPWH hpwh;
+	getHPWHObject(hpwh, input);	// get preset model 
+	ASSERTTRUE(hpwh.getMaxCompressorSetpoint() == expected);
+}
+
+void testGetMinOperatingTemp(string input, double expected) {
+	HPWH hpwh;
+	getHPWHObject(hpwh, input);	// get preset model 
+	ASSERTTRUE(hpwh.getMinOperatingTemp(HPWH::UNITS_F) == expected);
+}
+
+int main(int argc, char *argv[])
+{
+
+	const int length = 9;
+	const string models [length] = {"AOSmithHPTU50", "Stiebel220e","AOSmithCAHP120", \
+						"Sanden80", "ColmacCxV_5_SP", "ColmacCxA_20_SP", \
+						"TamScalable_SP", "restankRealistic", "StorageTank" };
+	const int hasComp[length] = { true, true, true, true, true, true, true, false, false };
+	const int coilConfig[length] = { 1, 1, 1, 2, 2, 2, 2, HPWH::HPWH_ABORT, HPWH::HPWH_ABORT };
+	const int heatCycle[length] = { true, true, true, false, false, false, false, HPWH::HPWH_ABORT, HPWH::HPWH_ABORT };
+	const double maxStpt[length] = { HPWH::MAXOUTLET_R134A, HPWH::MAXOUTLET_R134A,HPWH::MAXOUTLET_R134A,
+								HPWH::MAXOUTLET_R744, HPWH::MAXOUTLET_R410A, HPWH::MAXOUTLET_R134A,
+								HPWH::MAXOUTLET_R134A, HPWH::HPWH_ABORT, HPWH::HPWH_ABORT };
+
+	const double minTemp[length] = { 42., 32., 47., -273.15, -4., 40., 40., HPWH::HPWH_ABORT, HPWH::HPWH_ABORT };
+
+	for (int i = 0; i < length; i++) {
+		testHasACompressor(models[i], hasComp[i]);
+		testGetCompCoilConfig(models[i], coilConfig[i]);
+		testIsCompressorMultipass(models[i], heatCycle[i]);
+
+		testGetMaxCompressorSetpoint(models[i], maxStpt[i]);
+		testGetMinOperatingTemp(models[i], minTemp[i]);
+	}
+
+	//Made it through the gauntlet
+	return 0;
+}

--- a/test/testResistanceFcts.cc
+++ b/test/testResistanceFcts.cc
@@ -209,7 +209,6 @@ int main(int argc, char *argv[])
 
 	testGetSetResistanceErrors(); // Check can make ER residential tank with one lower element, and can't set/get upper
 
-	// Should move these to a seperate build later.
 	testCommercialTankInitErrors(); // test it inits as expected
 	testGetNumResistanceElements(); // unit test on getNumResistanceElements()
 	testGetResistancePositionInRETank(); // unit test on getResistancePosition() for an RE tank


### PR DESCRIPTION
- Fix bug with Sanden that  doesn't have a min operating temperature, now set to -25F. 
- isCompressorMultipass()
- getCompressorCoilConfig()
- getMaxCompressorSetpoint()
