### PR TITLE
Res Tank Generic with R-value

### DIFF
--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -140,8 +140,7 @@ class HPWH {
 	  // Non-preset models
 	  MODELS_CustomFile = 200,      /**< HPWH parameters were input via file */
 	  MODELS_CustomResTank = 201,   /**< HPWH parameters were input via HPWHinit_resTank */
-	  MODELS_CustomComResTank = 202,   /**< HPWH parameters were input via HPWHinit_commercialResTank */
-	  MODELS_CustomComResTankSwing = 203,   /**< HPWH parameters were input via HPWHinit_commercialResTank, specific swing tank controls */
+	  MODELS_CustomResTankGeneric = 202,   /**< HPWH parameters were input via HPWHinit_commercialResTank */
 
 	  // Larger Colmac models in single pass configuration 
 	  MODELS_ColmacCxV_5_SP  = 210,  /**<  Colmac CxA_5 external heat pump in Single Pass Mode  */
@@ -322,14 +321,13 @@ class HPWH {
    * to standard setting, with upper as VIP activating when the top third is too cold.
    */
  
-  int HPWHinit_commercialResTank(double tankVol, double upperPower_W, double lowerPower_W, MODELS resTankType);
-  /**< This function will initialize a HPWH object to be a large commercial resistance storage water heater.
-  * The UA is defaulted to meet the federal minimum standby losses based on the volume. 
+  int HPWHinit_resTankGeneric(double tankVol, double rValue, double upperPower_W, double lowerPower_W);
+  /**< This function will initialize a HPWH object to be a generic resistance storage water heater,
+  * with a specific R-Value defined at initalization. 
   *
   * Several assumptions regarding the tank configuration are assumed: the lower element
-  * is at the bottom, the upper element is at the top third.
-  * 
-  * resTankType's types support thus far are MODELS_CustomComResTank, MODELS_CustomComResSwingTank. 
+  * is at the bottom, the upper element is at the top third. The controls are the same standard controls for 
+  * the HPWHinit_resTank()
   */
 
   int HPWHinit_genericHPWH(double tankVol_L, double energyFactor, double resUse_C);

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -321,7 +321,7 @@ class HPWH {
    * to standard setting, with upper as VIP activating when the top third is too cold.
    */
  
-  int HPWHinit_resTankGeneric(double tankVol, double rValue, double upperPower_W, double lowerPower_W);
+  int HPWHinit_resTankGeneric(double tankVol, double rValue_FT2HrFperBTU, double upperPower_W, double lowerPower_W);
   /**< This function will initialize a HPWH object to be a generic resistance storage water heater,
   * with a specific R-Value defined at initalization. 
   *

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -321,9 +321,9 @@ class HPWH {
    * to standard setting, with upper as VIP activating when the top third is too cold.
    */
  
-  int HPWHinit_resTankGeneric(double tankVol, double rValue_FT2HrFperBTU, double upperPower_W, double lowerPower_W);
+  int HPWHinit_resTankGeneric(double tankVol_L, double rValue_M2KperW, double upperPower_W, double lowerPower_W);
   /**< This function will initialize a HPWH object to be a generic resistance storage water heater,
-  * with a specific R-Value defined at initalization. 
+  * with a specific R-Value defined at initalization.
   *
   * Several assumptions regarding the tank configuration are assumed: the lower element
   * is at the bottom, the upper element is at the top third. The controls are the same standard controls for 

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -129,7 +129,7 @@ int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPo
 }
 
 
-int HPWH::HPWHinit_resTankGeneric(double tankVol_L, double rValue_FT2HrFperBTU, double upperPower_W, double lowerPower_W) {
+int HPWH::HPWHinit_resTankGeneric(double tankVol_L, double rValue_M2KperW, double upperPower_W, double lowerPower_W) {
 
 	setAllDefaults(); // reset all defaults if you're re-initilizing
 	// sets simHasFailed = true; this gets cleared on successful completion of init
@@ -148,7 +148,7 @@ int HPWH::HPWHinit_resTankGeneric(double tankVol_L, double rValue_FT2HrFperBTU, 
 		}
 		return HPWH_ABORT;
 	}
-	if (rValue_FT2HrFperBTU <= 0.) {
+	if (rValue_M2KperW <= 0.) {
 		if (hpwhVerbosity >= VRB_reluctant) {
 			msg("R-Value is equal to or below 0.  DOES NOT COMPUTE\n");
 		}
@@ -209,9 +209,9 @@ int HPWH::HPWHinit_resTankGeneric(double tankVol_L, double rValue_FT2HrFperBTU, 
 	}
 
 	// Calc UA
-	double SA_FT2 = getTankSurfaceArea(tankVol_L, HPWH::UNITS_L, HPWH::UNITS_FT2);
-	double tankUA_BTUperHrF = SA_FT2 / rValue_FT2HrFperBTU;
-	tankUA_kJperHrC = UAf_TO_UAc(tankUA_BTUperHrF);
+	double SA_M2 = getTankSurfaceArea(tankVol_L, HPWH::UNITS_L, HPWH::UNITS_M2);
+	double tankUA_WperK = SA_M2 / rValue_M2KperW;
+	tankUA_kJperHrC = tankUA_WperK * 3.6; // 3.6 = 3600 S/Hr and 1/1000 kJ/J
 
 	if (tankUA_kJperHrC < 0.) {
 		if (hpwhVerbosity >= VRB_reluctant && tankUA_kJperHrC < -0.1) {

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -129,7 +129,7 @@ int HPWH::HPWHinit_resTank(double tankVol_L, double energyFactor, double upperPo
 }
 
 
-int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, double lowerPower_W, MODELS resTankType) {
+int HPWH::HPWHinit_resTankGeneric(double tankVol_L, double rValue_FT2HrFperBTU, double upperPower_W, double lowerPower_W) {
 
 	setAllDefaults(); // reset all defaults if you're re-initilizing
 	// sets simHasFailed = true; this gets cleared on successful completion of init
@@ -148,9 +148,9 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 		}
 		return HPWH_ABORT;
 	}
-	if (resTankType < MODELS_CustomComResTank || resTankType > MODELS_CustomComResTankSwing) {// if resTankType not supported here
+	if (rValue_FT2HrFperBTU <= 0.) {
 		if (hpwhVerbosity >= VRB_reluctant) {
-			msg("Resistance Tank Type not supported here");
+			msg("R-Value is equal to or below 0.  DOES NOT COMPUTE\n");
 		}
 		return HPWH_ABORT;
 	}
@@ -195,15 +195,8 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 		HeatSource resistiveElementBottom(this);
 		resistiveElementBottom.setupAsResistiveElement(0, lowerPower_W);
 
-		if (resTankType == MODELS_CustomComResTank) {
-			//standard logic conditions
-			resistiveElementBottom.addTurnOnLogic(HPWH::bottomThird(dF_TO_dC(40.)));
-			resistiveElementBottom.addTurnOnLogic(HPWH::standby(dF_TO_dC(10.)));
-		}
-		else if (resTankType == MODELS_CustomComResTankSwing) {
-			//swing tank logic
-			resistiveElementBottom.addTurnOnLogic(HPWH::topThird(dF_TO_dC(8.))); // replace with swing tank logic
-		}
+		resistiveElementBottom.addTurnOnLogic(HPWH::bottomThird(dF_TO_dC(40.)));
+		resistiveElementBottom.addTurnOnLogic(HPWH::standby(dF_TO_dC(10.)));
 
 		// set everything in it's correct place
 		if (numHeatSources == 1) {// if one only one slot
@@ -216,14 +209,8 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 	}
 
 	// Calc UA
-	// S <= .3 + 27/ Vm (%/hr) 
-	// SL = S(%/h)/100 * 8.25 (BTU/galF) * Vm (gal) * (140 – 75) (F)
-	// SL = UA deltaT. So deltaT actually cancels. 
-	// UA (BTU/hr/F) = 8.25 (BTU/galF) * (.3 + 27/Vm)(%/hr)/100 * Vm = 8.25 * (.3*Vm + 27 [G]) / 100,
-	// where 8.25 is actually density times heat capacity
-	double tankVol_GAL = L_TO_GAL(tankVol_L);
-	double S_PercperHr= (0.3 + 27. / tankVol_GAL);
-	double tankUA_BTUperHrF = 8.25 * S_PercperHr / 100. * tankVol_GAL; // Note (0.3+27.tankVol_GAL) has units %/hr
+	double SA_FT2 = getTankSurfaceArea(tankVol_L, HPWH::UNITS_L, HPWH::UNITS_FT2);
+	double tankUA_BTUperHrF = SA_FT2 / rValue_FT2HrFperBTU;
 	tankUA_kJperHrC = UAf_TO_UAc(tankUA_BTUperHrF);
 
 	if (tankUA_kJperHrC < 0.) {
@@ -233,7 +220,7 @@ int HPWH::HPWHinit_commercialResTank(double tankVol_L, double upperPower_W, doub
 		tankUA_kJperHrC = 0.0;
 	}
 
-	hpwhModel = resTankType;
+	hpwhModel = HPWH::MODELS_CustomResTankGeneric;
 
 	//calculate oft-used derived values
 	calcDerivedValues();

--- a/test/testResistanceFcts.cc
+++ b/test/testResistanceFcts.cc
@@ -157,8 +157,8 @@ struct InsulationPoint {
 	double expectedUA_SI;
 };
 
-#define INITGEN(point) 	hpwh.HPWHinit_resTankGeneric(point.volume_L, point.rValue_IP, elementPower_kW * 1000., elementPower_kW * 1000.);
-
+#define R_TO_RSI(rvalue) rvalue * 0.176110
+#define INITGEN(point) 	hpwh.HPWHinit_resTankGeneric(point.volume_L, R_TO_RSI(point.rValue_IP), elementPower_kW * 1000., elementPower_kW * 1000.)
 void testCommercialTankInit() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
@@ -176,41 +176,43 @@ void testCommercialTankInit() {
 	// Check UA is as expected at 800 gal
 	INITGEN(testPoint800);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI, 0.0001));
 	// Check UA independent of elements
-	hpwh.HPWHinit_resTankGeneric(testPoint800.volume_L, testPoint800.rValue_IP, elementPower_kW, elementPower_kW);
+	hpwh.HPWHinit_resTankGeneric(testPoint800.volume_L, R_TO_RSI(testPoint800.rValue_IP), elementPower_kW, elementPower_kW);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI, 0.0001));
 
 	// Check UA is as expected at 2 gal
 	INITGEN(testPoint2);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint2.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint2.expectedUA_SI, 0.0001));
 
 	// Check UA is as expected at 50 gal
 	INITGEN(testPoint50);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint50.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint50.expectedUA_SI, 0.0001));
 
 	// Check UA is as expected at 200 gal
 	INITGEN(testPoint200);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint200.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint200.expectedUA_SI, 0.0001));
 
 	INITGEN(testPoint200B);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint200B.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint200B.expectedUA_SI, 0.0001));
 
 	// Check UA is as expected at 2000 gal
 	INITGEN(testPoint2000);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint2000.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint2000.expectedUA_SI, 0.0001));
 
 	// Check UA is as expected at 20000 gal
 	INITGEN(testPoint20000);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, testPoint20000.expectedUA_SI));
+	ASSERTTRUE(relcmpd(UA, testPoint20000.expectedUA_SI, 0.0001));
 }
+#undef INITGEN
+#undef R_TO_RSI
 
 int main(int argc, char *argv[])
 {

--- a/test/testResistanceFcts.cc
+++ b/test/testResistanceFcts.cc
@@ -52,42 +52,39 @@ void testGetSetResistanceErrors() {
 void testCommercialTankInitErrors() {
 	HPWH hpwh;
 	// init model 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(-800., 100., 100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative volume
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., -100., 100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative element
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., -100., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // negative element
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_CustomResTank) == HPWH::HPWH_ABORT); // non commercial restank
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 100., 100., HPWH::MODELS_restankRealistic) == HPWH::HPWH_ABORT); // non custom restank
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(-800., 10., 100., 100.) == HPWH::HPWH_ABORT); // negative volume
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(800., 10., -100., 100.) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(800., 10., 100., -100.) == HPWH::HPWH_ABORT); // negative element
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(800., -10., 100., 100.) == HPWH::HPWH_ABORT); // negative r value
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(800., 0., 100., 100.) == HPWH::HPWH_ABORT); // 0 r value
+	ASSERTTRUE(hpwh.HPWHinit_resTankGeneric(800., 10., 0., 0.) == HPWH::HPWH_ABORT); // Check needs one element
 }
 
 void testGetNumResistanceElements() {
 	HPWH hpwh;
 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // Check needs one element
-
-	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 0., 1000.);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
-	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 1000., 0.);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 1); // Check 1 elements
-	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 1000., 1000.);
 	ASSERTTRUE(hpwh.getNumResistanceElements() == 2); // Check 2 elements
 }
 
 void testGetResistancePositionInRETank() {
 	HPWH hpwh;
 
-	ASSERTTRUE(hpwh.HPWHinit_commercialResTank(800., 0., 0., HPWH::MODELS_CustomComResTank) == HPWH::HPWH_ABORT); // Check needs one element
-
-	hpwh.HPWHinit_commercialResTank(800., 0., 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 0., 1000.);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 0); // Check lower element is there 
 	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no element
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no element
 
-	hpwh.HPWHinit_commercialResTank(800., 1000., 0., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 1000., 0.);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
 	ASSERTTRUE(hpwh.getResistancePosition(1) == HPWH::HPWH_ABORT); // Check no elements
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check no elements
 
-	hpwh.HPWHinit_commercialResTank(800., 1000., 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 1000., 1000.);
 	ASSERTTRUE(hpwh.getResistancePosition(0) == 8); // Check upper element there
 	ASSERTTRUE(hpwh.getResistancePosition(1) == 0); // Check lower element is there 
 	ASSERTTRUE(hpwh.getResistancePosition(2) == HPWH::HPWH_ABORT); // Check 0 elements}
@@ -111,7 +108,7 @@ void testCommercialTankErrorsWithBottomElement() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	// init model 
-	hpwh.HPWHinit_commercialResTank(800., 0., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., 0., elementPower_kW * 1000.);
 
 	// Check only lowest setting works
 	double factor = 3.;
@@ -134,7 +131,7 @@ void testCommercialTankErrorsWithTopElement() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	// init model 
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., 0., HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(800., 10., elementPower_kW * 1000., 0.);
 
 	// Check only bottom setting works
 	double factor = 3.;
@@ -154,57 +151,69 @@ void testCommercialTankErrorsWithTopElement() {
 	ASSERTTRUE(hpwh.setResistanceCapacity(factor * elementPower_kW, 2, HPWH::UNITS_KW) == HPWH::HPWH_ABORT);
 }
 
+struct InsulationPoint {
+	double volume_L;
+	double rValue_IP;
+	double expectedUA_SI;
+};
+
+#define INITGEN(point) 	hpwh.HPWHinit_resTankGeneric(point.volume_L, point.rValue_IP, elementPower_kW * 1000., elementPower_kW * 1000.);
+
 void testCommercialTankInit() {
 	HPWH hpwh;
 	double elementPower_kW = 10.; //KW
 	double UA;
 	const double UA800 = 14.16395482;
-	const double UA2 = 4.255156932;
-	const double UA50 = 4.851174851;
-	const double UA200 = 6.713730845;
-	const double UA2000 = 29.06440278;
-	const double UA20000 = 252.5711221;
+	const InsulationPoint testPoint800 = { 800., 10., 10.500366 };
+	const InsulationPoint testPoint2 = { 2., 6., 0.322364 };
+	const InsulationPoint testPoint50 = { 50., 12., 1.37808 };
+	const InsulationPoint testPoint200 = { 200., 16., 2.604420 };
+	const InsulationPoint testPoint200B = { 200., 6., 6.94512163 };
+	const InsulationPoint testPoint2000 = { 2000., 16., 12.0886496 };
+	const InsulationPoint testPoint20000 = { 20000., 6., 149.628109 };
+
 
 	// Check UA is as expected at 800 gal
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint800);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA800));
+	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI));
 	// Check UA independent of elements
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW, elementPower_kW, HPWH::MODELS_CustomComResTank);
+	hpwh.HPWHinit_resTankGeneric(testPoint800.volume_L, testPoint800.rValue_IP, elementPower_kW, elementPower_kW);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA800));
-	// Check UA independent of model
-	hpwh.HPWHinit_commercialResTank(800., elementPower_kW, elementPower_kW, HPWH::MODELS_CustomComResTankSwing);
-	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA800));
-
+	ASSERTTRUE(relcmpd(UA, testPoint800.expectedUA_SI));
 
 	// Check UA is as expected at 2 gal
-	hpwh.HPWHinit_commercialResTank(2., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint2);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA2));
+	ASSERTTRUE(relcmpd(UA, testPoint2.expectedUA_SI));
+
 	// Check UA is as expected at 50 gal
-	hpwh.HPWHinit_commercialResTank(50., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint50);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA50));
+	ASSERTTRUE(relcmpd(UA, testPoint50.expectedUA_SI));
+
 	// Check UA is as expected at 200 gal
-	hpwh.HPWHinit_commercialResTank(200., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint200);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA200));
+	ASSERTTRUE(relcmpd(UA, testPoint200.expectedUA_SI));
+
+	INITGEN(testPoint200B);
+	hpwh.getUA(UA);
+	ASSERTTRUE(relcmpd(UA, testPoint200B.expectedUA_SI));
+
 	// Check UA is as expected at 2000 gal
-	hpwh.HPWHinit_commercialResTank(2000., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint2000);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA2000));
+	ASSERTTRUE(relcmpd(UA, testPoint2000.expectedUA_SI));
+
 	// Check UA is as expected at 20000 gal
-	hpwh.HPWHinit_commercialResTank(20000., elementPower_kW * 1000., elementPower_kW * 1000., HPWH::MODELS_CustomComResTank);
+	INITGEN(testPoint20000);
 	hpwh.getUA(UA);
-	ASSERTTRUE(relcmpd(UA, UA20000));
+	ASSERTTRUE(relcmpd(UA, testPoint20000.expectedUA_SI));
 }
 
 int main(int argc, char *argv[])
 {
-
-
 	testSetResistanceCapacityErrorChecks(); // Check the resistance reset throws errors when expected.
 
 	testGetSetResistanceErrors(); // Check can make ER residential tank with one lower element, and can't set/get upper


### PR DESCRIPTION
- Change HPWHinit_commercialResTank() to HPWHinit_resTankGeneric().
  - Input for R value in IP units.
  - Replace commercial enums with MODELS_CustomResTankGeneric.