### PR TITLE
Fix heat-distribution initialization.

### DIFF
--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -383,9 +383,7 @@ void HPWH::HeatSource::addHeat(double externalT_C,double minutesToRun) {
 	case CONFIG_SUBMERGED:
 	case CONFIG_WRAPPED:
 	{
-		static std::vector<double> heatDistribution;
-		if (heatDistribution.size() != hpwh->getNumNodes())
-			heatDistribution.resize(hpwh->getNumNodes());
+		std::vector<double> heatDistribution(hpwh->getNumNodes());
 
 		//calcHeatDist takes care of the swooping for wrapped configurations
 		calcHeatDist(heatDistribution);

--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -383,7 +383,10 @@ void HPWH::HeatSource::addHeat(double externalT_C,double minutesToRun) {
 	case CONFIG_SUBMERGED:
 	case CONFIG_WRAPPED:
 	{
-		static std::vector<double> heatDistribution(hpwh->getNumNodes());
+		static std::vector<double> heatDistribution;
+		if (heatDistribution.size() != hpwh->getNumNodes())
+			heatDistribution.resize(hpwh->getNumNodes());
+
 		//calcHeatDist takes care of the swooping for wrapped configurations
 		calcHeatDist(heatDistribution);
 


### PR DESCRIPTION
## Description
- Fixes an issue that arises in cse. cse re-uses HPWH objects as different models during testing. heatDistribution is declared as static in HeatSource::addHeat, which avoids reinitializing the std::vector with each pass, but if the number of nodes changes, the vector size will change.

## Author Progress Checklist:

- [X] Open draft pull request
    - [X] Make title clearly understandable in a standalone change log context
    - [X] Assign yourself the issue
    - [X] Add at least one label (enhancement, bug, or maintenance)
    - [ ] Link the issue(s) addressed by this PR (under "Development" in the sidebar menu) 
- [X] Make code changes (if you haven't already)
- [X] Self-review of code
    - [X] My code follows the style guidelines of this project
    - [X] I have added comments to my code, particularly in hard-to-understand areas
    - [X] I have only committed the necessary changes for this fix or feature
    - [X] I have made corresponding changes to the documentation
    - [X] My changes generate no new warnings
    - [X] I have ensured that my fix is effective or that my feature works as intended by:
        - [x] exercising the code changes in the test framework, and/or
        - [X] manually verifying the changes (as explained in the the pull request description above)
    - [X] My changes pass all local tests
    - [X] My changes successfully passes CI checks
    - [X] Add any unit test for proof and documentation.
    - [X] Merge in main branch and address resulting conflicts and/or test failures.
- [X] Move pull request out of draft mode and assign reviewers
- [] Iterate with reviewers until all changes are approved
    - [ ] Make changes in response to reviewer comments
    - [ ] Merge in main branch and address resulting conflicts and/or test failures.
    - [ ] Re-request review in GitHub

## Reviewer Checklist:

 - [ ] Read the pull request description
 - [ ] Perform a code review on GitHub
 - [ ] Confirm all CI checks pass and there are no build warnings
 - [ ] Pull, build, and run automated tests locally
 - [ ] Perform manual tests of the fix or feature locally
 - [ ] Add any review comments, if applicable
 - [ ] Submit review in GitHub as either
     - [ ] Request changes, or
     - [ ] Approve
 - [ ] Iterate with author until all changes are approved