### PR TITLE
Fix extra-heat assignment

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -2681,6 +2681,8 @@ void HPWH::addExtraHeat(std::vector<double> &nodePowerExtra_W,double tankAmbient
 			heatSources[i].perfMap.clear();
 			heatSources[i].energyInput_kWh = 0.0;
 			heatSources[i].energyOutput_kWh = 0.0;
+
+			break; // Only add extra heat to the first "extra" heat source found.
 		}
 	}
 }

--- a/src/HPWH.in.hh
+++ b/src/HPWH.in.hh
@@ -1020,6 +1020,10 @@ public:
 	void setupAsResistiveElement(int node,double Watts,int condensitySize = CONDENSITY_SIZE);
 	/**< configure the heat source to be a resisive element, positioned at the
 		specified node, with the specified power in watts */
+
+	void setupExtraHeat(const double extraPower_W);
+	/**< Sets the power provided by this heat source to extraPower_W*/
+
 	void setupExtraHeat(std::vector<double> &nodePowerExtra_W);
 	/**< Configure a user-defined heat source added as extra, based off using
 		  nodePowerExtra_W as the total watt input and the condensity*/

--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -514,7 +514,7 @@ void HPWH::HeatSource::getCapacity(double externalT_C,double condenserTemp_C,dou
 		std::vector<double> target{externalT_F,Tout_F,condenserTemp_F};
 		btwxtInterp(input_BTUperHr,cop,target);
 	} else {
-		if(perfMap.empty()) {
+		if(perfMap.empty()) { // Avoid using empty perfMap
 			input_BTUperHr = 0.;
 			cop = 0.;
 		} else if(perfMap.size() > 1) {

--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -989,27 +989,31 @@ void HPWH::HeatSource::setupAsResistiveElement(int node,double Watts,int condens
 	typeOfHeatSource = TYPE_resistance;
 }
 
-void HPWH::HeatSource::setupExtraHeat(std::vector<double> &nodePowerExtra_W) {
-	// The total power in nodePowerExtra_W is applied, using the existing condensity.
-	double watts = 0.;
-	for(unsigned int i = 0; i < nodePowerExtra_W.size(); ++i) {
-		watts += nodePowerExtra_W[i];
-	}
+void HPWH::HeatSource::setupExtraHeat(const double extraPower_W) {
 
 	perfMap.clear();
 	perfMap.reserve(2);
 
 	perfMap.push_back({
 		50, // Temperature (T_F)
-		{watts,0.0,0.0}, // Input Power Coefficients (inputPower_coeffs)
+		{extraPower_W,0.0,0.0}, // Input Power Coefficients (inputPower_coeffs)
 		{1.0,0.0,0.0} // COP Coefficients (COP_coeffs)
 		});
 
 	perfMap.push_back({
 		67, // Temperature (T_F)
-		{watts,0.0,0.0}, // Input Power Coefficients (inputPower_coeffs)
+		{extraPower_W,0.0,0.0}, // Input Power Coefficients (inputPower_coeffs)
 		{1.0,0.0,0.0} // COP Coefficients (COP_coeffs)
 		});
+}
+
+void HPWH::HeatSource::setupExtraHeat(std::vector<double> &nodePowerExtra_W) {
+	// Only the total power in nodePowerExtra_W is used.
+	double extraPower_W = 0.;
+	for(unsigned int i = 0; i < nodePowerExtra_W.size(); ++i) {
+		extraPower_W += nodePowerExtra_W[i];
+	}
+	setupExtraHeat(extraPower_W);
 }
 
 void HPWH::HeatSource::addTurnOnLogic(std::shared_ptr<HeatingLogic> logic) {

--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -990,33 +990,14 @@ void HPWH::HeatSource::setupAsResistiveElement(int node,double Watts,int condens
 }
 
 void HPWH::HeatSource::setupExtraHeat(std::vector<double> &nodePowerExtra_W) {
-	// The elements of nodePowerExtra_W are assigned to the condensity nodes for
-	// this heat source. If condensity.size() is larger than nodePowerExtra_W.size,
-	// the additional elements of condensity are set to zero. If condensity.size() is smaller than nodePowerExtra_W.size,
-	// the additional elements of nodePowerExtra_W are omitted.
-	// Suggest specifying nodePowerExtra_W as the full condensity distribution (scaled by power) instead.
-	for(unsigned int i = 0; i < condensity.size(); ++i) {
-
-		//put into vector for normalization
-		condensity[i] = (i < nodePowerExtra_W.size()) ? nodePowerExtra_W[i] : 0.;
-	}
-	normalize(condensity);
-
-	if(hpwh->hpwhVerbosity >= VRB_emetic){
-		hpwh->msg("extra heat condensity: ");
-		for(unsigned int i = 0; i < condensity.size(); i++) {
-			hpwh->msg("C[%d]: %f",i,condensity[i]);
-		}
-		hpwh->msg("\n ");
-	}
-
-	perfMap.clear();
-	perfMap.reserve(2);
-
+	// The total power in nodePowerExtra_W is applied, using the existing condensity.
 	double watts = 0.;
 	for(unsigned int i = 0; i < nodePowerExtra_W.size(); ++i) {
 		watts += nodePowerExtra_W[i];
 	}
+
+	perfMap.clear();
+	perfMap.reserve(2);
 
 	perfMap.push_back({
 		50, // Temperature (T_F)
@@ -1029,7 +1010,6 @@ void HPWH::HeatSource::setupExtraHeat(std::vector<double> &nodePowerExtra_W) {
 		{watts,0.0,0.0}, // Input Power Coefficients (inputPower_coeffs)
 		{1.0,0.0,0.0} // COP Coefficients (COP_coeffs)
 		});
-
 }
 
 void HPWH::HeatSource::addTurnOnLogic(std::shared_ptr<HeatingLogic> logic) {

--- a/src/HPWHHeatSources.cc
+++ b/src/HPWHHeatSources.cc
@@ -433,7 +433,8 @@ void HPWH::HeatSource::addHeat(double externalT_C,double minutesToRun) {
 
 	case CONFIG_EXTERNAL:
 		//Else the heat source is external. SANCO2 system is only current example
-		//capacity is calculated internal to this function, and cap/input_BTUperHr, cop are outputs
+		//capacity is calculated internal to this functio
+		// n, and cap/input_BTUperHr, cop are outputs
 		this->runtime_min = addHeatExternal(externalT_C,minutesToRun,cap_BTUperHr,input_BTUperHr,cop);
 		break;
 	}
@@ -513,7 +514,10 @@ void HPWH::HeatSource::getCapacity(double externalT_C,double condenserTemp_C,dou
 		std::vector<double> target{externalT_F,Tout_F,condenserTemp_F};
 		btwxtInterp(input_BTUperHr,cop,target);
 	} else {
-		if(perfMap.size() > 1) {
+		if(perfMap.empty()) {
+			input_BTUperHr = 0.;
+			cop = 0.;
+		} else if(perfMap.size() > 1) {
 			double COP_T1,COP_T2;    			   //cop at ambient temperatures T1 and T2
 			double inputPower_T1_Watts,inputPower_T2_Watts; //input power at ambient temperatures T1 and T2
 

--- a/src/HPWHpresets.cc
+++ b/src/HPWHpresets.cc
@@ -537,7 +537,7 @@ int HPWH::HPWHinit_presets(MODELS presetNum) {
 		extra.addTurnOnLogic(HPWH::topThird_absolute(1));
 
 		//initial guess, will get reset based on the input heat vector
-		extra.setCondensity({1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+		extra.setCondensity({1., 0., 0., 0.});
 
 		//set everything in its places
 		heatSources.resize(1);

--- a/test/testHeatingLogics.cc
+++ b/test/testHeatingLogics.cc
@@ -288,7 +288,7 @@ void testExtraHeat() {
 	hpwh.runOneStep(0, ambientT_C, externalT_C, HPWH::DR_LOC, inletVol2_L, inletT2_C, &nodePowerExtra_W);
 	double Q_final = hpwh.getTankHeatContent_kJ();
 
-	double dQ_actual_kJ = (Q_final - Q_init) * 1.055055853 / 1.055; // Correct for approx. BU->kJ conversion.
+	double dQ_actual_kJ = (Q_final - Q_init) * 1.055055853 / 1.055; // Correct for approx. BTU->kJ conversion.
 
 	double dQ_expected_kJ = extraPower_W * 60. / 1.e3; // 1 min
 

--- a/test/testHeatingLogics.cc
+++ b/test/testHeatingLogics.cc
@@ -20,6 +20,7 @@ void testChangeToStateofChargeControlled(string& input);
 void testSetStateOfCharge(string& input);
 
 void testSetStateOfCharge(string& input, double coldWater_F, double minTUse_F, double tankTAt76SoC);
+void testExtraHeat();
 
 const std::vector<string> hasHighShuttOffVectSP = { "Sanden80", "QAHV_N136TAU_HPB_SP", \
 	"ColmacCxA_20_SP", "ColmacCxV_5_SP", "NyleC60A_SP", "NyleC60A_C_SP", "NyleC185A_C_SP", "TamScalable_SP" };
@@ -62,6 +63,7 @@ int main(int, char*) {
 		testCanNotSetEnteringWaterShutOff(hpwhStr);
 	}
 
+	testExtraHeat();
 	return 0;
 }
 
@@ -263,4 +265,32 @@ void testSetStateOfCharge(string& input, double coldWater_F, double minTUse_F, d
 	hpwh.setTargetSoCFraction(0.70);
 	hpwh.runOneStep(0, externalT_C, externalT_C, HPWH::DR_ALLOW);
 	ASSERTFALSE(compressorIsRunning(hpwh));
+}
+
+/*Test adding extra heat to a tank for one minute*/
+void testExtraHeat() {
+	HPWH hpwh;
+	getHPWHObject(hpwh, "StorageTank");
+
+	const double ambientT_C = 20.;
+	const double externalT_C = 20.;
+	const double inletVol2_L = 0.;
+	const double inletT2_C = 0.;
+
+	double extraPower_W = 1000.;
+	std::vector<double> nodePowerExtra_W = {extraPower_W};
+
+	//
+	hpwh.setUA(0.);
+	hpwh.setTankToTemperature(20.);
+
+	double Q_init = hpwh.getTankHeatContent_kJ();
+	hpwh.runOneStep(0, ambientT_C, externalT_C, HPWH::DR_LOC, inletVol2_L, inletT2_C, &nodePowerExtra_W);
+	double Q_final = hpwh.getTankHeatContent_kJ();
+
+	double dQ_actual_kJ = (Q_final - Q_init) * 1.055055853 / 1.055; // Correct for approx. BU->kJ conversion.
+
+	double dQ_expected_kJ = extraPower_W * 60. / 1.e3; // 1 min
+
+	ASSERTTRUE(cmpd(dQ_actual_kJ, dQ_expected_kJ));
 }


### PR DESCRIPTION
## Description
- Addresses the failure of the dhw_solar test in cse. The problem resulted from the use of "extra" heat supplied by solar to a storage tank. HPWHsim is configured to receive a pointer to a std::vector<double> of power values, but the interpretation of these values is a bit ambiguous. cse only provides a vector of three equal heat values, which are applied to the first three condensity nodes of an "extra" heat source. Presumably, this was intended for a heat source with CONDENSITY_SIZE = 12, with the additional nine nodes having zero weight. But this lacks flexibility and is inconsistent with the preset configuration, so it is now reinterpreted as providing a total power, with the condensity unchanged. An overloaded form of setExtraHeat was added that receives a double value called extraPower_W. 
- I suggest the minor change in cse of supplying only the total power via a double value. We can modify the older version of setExtraHeat to accept a weighted condensity, if needed, after that change is made, which would enable fully user-defined heat to be specified in cse.
- A simple extra-heat test was added. It heats a fully insulated tank with 1000 W for one minute, then checks that the heat content increased, accordingly. A minor change was made to avoid an error that occurs when running HeatSource::getCapacity before defining performance specs.
- These changes pass all tests in cse and HPWHsim. 

## Author Progress Checklist:

- [X] Open draft pull request
    - [X] Make title clearly understandable in a standalone change log context
    - [X] Assign yourself the issue
    - [X] Add at least one label (enhancement, bug, or maintenance)
    - [ ] Link the issue(s) addressed by this PR (under "Development" in the sidebar menu) 
- [X] Make code changes (if you haven't already)
- [X] Self-review of code
    - [X] My code follows the style guidelines of this project
    - [X] I have added comments to my code, particularly in hard-to-understand areas
    - [X] I have only committed the necessary changes for this fix or feature
    - [X] I have made corresponding changes to the documentation
    - [X] My changes generate no new warnings
    - [X] I have ensured that my fix is effective or that my feature works as intended by:
        - [x] exercising the code changes in the test framework, and/or
        - [X] manually verifying the changes (as explained in the the pull request description above)
    - [X] My changes pass all local tests
    - [X] My changes successfully passes CI checks
    - [X] Add any unit test for proof and documentation.
    - [X] Merge in main branch and address resulting conflicts and/or test failures.
- [X] Move pull request out of draft mode and assign reviewers
- [] Iterate with reviewers until all changes are approved
    - [ ] Make changes in response to reviewer comments
    - [ ] Merge in main branch and address resulting conflicts and/or test failures.
    - [ ] Re-request review in GitHub

## Reviewer Checklist:

 - [ ] Read the pull request description
 - [ ] Perform a code review on GitHub
 - [ ] Confirm all CI checks pass and there are no build warnings
 - [ ] Pull, build, and run automated tests locally
 - [ ] Perform manual tests of the fix or feature locally
 - [ ] Add any review comments, if applicable
 - [ ] Submit review in GitHub as either
     - [ ] Request changes, or
     - [ ] Approve
 - [ ] Iterate with author until all changes are approved