### PR TITLE
Update CI actions for Ubuntu

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
             cxx: g++-11
             experimental: false
           - os: ubuntu
-            os_ver: "20.04"
+            os_ver: "22.04"
             config: Release
             coverage: false
             cc: gcc-10
@@ -37,7 +37,7 @@ jobs:
             cxx: clang++
             experimental: false
           - os: ubuntu
-            os_ver: "20.04"
+            os_ver: "22.04"
             config: Debug
             coverage: true
             cc: gcc-10


### PR DESCRIPTION
Changed build-and-test.yml to test using gcc-10 on ubuntu 22.04 (instead of 20.04, which is deprecated.)