### PR TITLE
Fix cases where a tank has two inlets

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3436,12 +3436,18 @@ void HPWH::resetTopOffTimer() { timerTOT = 0.; }
 ///	@param[in]	fracEnergyTolerance		Fractional tolerance for energy imbalance
 /// @return	true if balanced; false otherwise.
 //-----------------------------------------------------------------------------
-bool HPWH::isEnergyBalanced(const double drawVol_L,
+bool HPWH::isEnergyBalanced(const double inlet1_drawVol_L,
+                            const double inlet1T_C,
+                            const double inlet2_drawVol_L,
+                            const double inlet2T_C,
                             const double prevHeatContent_kJ,
                             const double fracEnergyTolerance /* = 0.001 */)
 {
-    double drawCp_kJperC =
-        CPWATER_kJperkgC * DENSITYWATER_kgperL * drawVol_L; // heat capacity of draw
+    double inlet1_drawCp_kJperC =
+        CPWATER_kJperkgC * DENSITYWATER_kgperL * inlet1_drawVol_L; // heat capacity of inlet1 draw
+
+    double inlet2_drawCp_kJperC =
+        CPWATER_kJperkgC * DENSITYWATER_kgperL * inlet2_drawVol_L; // heat capacity of inlet2 draw
 
     // Check energy balancing.
     double qInElectrical_kJ = 0.;
@@ -3452,8 +3458,9 @@ bool HPWH::isEnergyBalanced(const double drawVol_L,
     double qInExtra_kJ = KWH_TO_KJ(extraEnergyInput_kWh);
     double qInHeatSourceEnviron_kJ = getEnergyRemovedFromEnvironment(UNITS_KJ);
     double qOutTankEnviron_kJ = KWH_TO_KJ(standbyLosses_kWh);
-    double qOutWater_kJ =
-        drawCp_kJperC * (outletTemp_C - member_inletT_C); // assumes only one inlet
+    double qOutWater_kJ = inlet1_drawCp_kJperC * (outletTemp_C - inlet1T_C) +
+                          inlet2_drawCp_kJperC * (outletTemp_C - inlet2T_C);
+
     double expectedTankHeatContent_kJ =
         prevHeatContent_kJ        // previous heat content
         + qInElectrical_kJ        // electrical energy delivered to heat sources

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -2634,8 +2634,8 @@ bool HPWH::isEnergyBalanced(const double drawVol1_L,
     double drawCp2_kJperC =
         CPWATER_kJperkgC * DENSITYWATER_kgperL * drawVol2_L; // heat capacity of inlet2 draw
 
-    double qOutWater_kJ =
-        drawCp1_kJperC * (tank->getOutletT_C() - inlet1T_C) + drawCp2_kJperC * (tank->getOutletT_C() - inlet2T_C);
+    double qOutWater_kJ = drawCp1_kJperC * (tank->getOutletT_C() - inlet1T_C) +
+                          drawCp2_kJperC * (tank->getOutletT_C() - inlet2T_C);
 
     double expectedTankHeatContent_kJ =
         prevHeatContent_kJ        // previous heat content

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -2865,10 +2865,10 @@ void HPWH::updateTankTemps(double drawVolume_L,
                 totalExpelledHeat_kJ += outputHeat_kJ;
                 tankTemps_C.back() -= outputHeat_kJ / nodeCp_kJperC;
 
+                double inletFraction = 0.;
                 for (int i = getNumNodes() - 1; i >= 0; --i)
                 {
                     // combine all inlet contributions at this node
-                    double inletFraction = 0.;
                     if (i == highInletNodeIndex)
                     {
                         inletFraction += highInletFraction;

--- a/src/HPWH.hh
+++ b/src/HPWH.hh
@@ -394,7 +394,7 @@ class HPWH : public Courier::Sender
                     push_back({height, weight});
                     break;
                 }
-                if (weight != node_distribution[i + 1])
+                if (node_distribution[i] != node_distribution[i + 1])
                 {
                     push_back({height, weight});
                 }

--- a/src/HPWH.hh
+++ b/src/HPWH.hh
@@ -975,18 +975,30 @@ class HPWH : public Courier::Sender
     bool isSoCControlled() const;
 
     /// Checks whether energy is balanced during a simulation step.
-    bool isEnergyBalanced(const double drawVol_L,
+    bool isEnergyBalanced(const double inlet1_drawVol_L,
+                          const double inlet1T_C,
+                          const double inlet2_drawVol_L,
+                          const double inlet2T_C,
                           const double prevHeatContent_kJ,
                           const double fracEnergyTolerance = 0.001);
 
-    /// Overloaded version of above that allows specification of inlet temperature.
+    /// Overloaded version of above with one inlet only.
     bool isEnergyBalanced(const double drawVol_L,
                           double inletT_C_in,
                           const double prevHeatContent_kJ,
                           const double fracEnergyTolerance)
     {
-        setInletT(inletT_C_in);
-        return isEnergyBalanced(drawVol_L, prevHeatContent_kJ, fracEnergyTolerance);
+        return isEnergyBalanced(
+            drawVol_L, inletT_C_in, 0., 0., prevHeatContent_kJ, fracEnergyTolerance);
+    }
+
+    /// Overloaded version of above using current inletT
+    bool isEnergyBalanced(const double drawVol_L,
+                          const double prevHeatContent_kJ,
+                          const double fracEnergyTolerance = 0.001)
+    {
+        return isEnergyBalanced(
+            drawVol_L, member_inletT_C, prevHeatContent_kJ, fracEnergyTolerance);
     }
 
     /// Addition of heat from a normal heat sources; return excess heat, if needed, to prevent

--- a/src/HPWH.hh
+++ b/src/HPWH.hh
@@ -975,21 +975,21 @@ class HPWH : public Courier::Sender
     bool isSoCControlled() const;
 
     /// Checks whether energy is balanced during a simulation step.
-    bool isEnergyBalanced(const double inlet1_drawVol_L,
+    bool isEnergyBalanced(const double drawVol1_L,
                           const double inlet1T_C,
-                          const double inlet2_drawVol_L,
+                          const double drawVol2_L,
                           const double inlet2T_C,
                           const double prevHeatContent_kJ,
                           const double fracEnergyTolerance = 0.001);
 
     /// Overloaded version of above with one inlet only.
-    bool isEnergyBalanced(const double drawVol_L,
+    bool isEnergyBalanced(const double drawVol1_L,
                           double inletT_C_in,
                           const double prevHeatContent_kJ,
                           const double fracEnergyTolerance)
     {
         return isEnergyBalanced(
-            drawVol_L, inletT_C_in, 0., 0., prevHeatContent_kJ, fracEnergyTolerance);
+            drawVol1_L, inletT_C_in, 0., 0., prevHeatContent_kJ, fracEnergyTolerance);
     }
 
     /// Overloaded version of above using current inletT

--- a/src/Tank.cc
+++ b/src/Tank.cc
@@ -459,10 +459,10 @@ void HPWH::Tank::updateNodes(double drawVolume_L,
                 totalExpelledHeat_kJ += outputHeat_kJ;
                 nodeTs_C.back() -= outputHeat_kJ / nodeCp_kJperC;
 
+                double inletFraction = 0.; // accumulate inlet contributions
                 for (int i = getNumNodes() - 1; i >= 0; --i)
                 {
-                    // combine all inlet contributions at this node
-                    double inletFraction = 0.;
+
                     if (i == highInletNodeIndex)
                     {
                         inletFraction += highInletFraction;
@@ -578,7 +578,7 @@ void HPWH::Tank::setNodeNumFromFractionalHeight(double fractionalHeight, int& in
         send_error("Out of bounds fraction for setInletByFraction.");
     }
 
-    int node = (int)std::floor(getNumNodes() * fractionalHeight);
+    auto node = static_cast<int>(std::floor(getNumNodes() * fractionalHeight));
     inletNum = (node == getNumNodes()) ? getIndexTopNode() : node;
 }
 

--- a/test/unit_tests/energyBalanceTest.cpp
+++ b/test/unit_tests/energyBalanceTest.cpp
@@ -8,124 +8,128 @@
 #include "HPWH.hh"
 #include "unit-test.hh"
 
+struct EnergyBalanceTest : public testing::Test
+{
+    const double Pi = 4. * atan(1.);
+};
+
 /*
  * energyBalance tests
  */
-TEST(EnergyBalanceTest, energyBalance)
+TEST_F(EnergyBalanceTest, AOSmithHPTS50)
 {
-    const double Pi = 4. * atan(1.);
+    // get preset model
+    HPWH hpwh;
+    const std::string modelName = "AOSmithHPTS50";
+    hpwh.initPreset(modelName);
 
-    /* no extra heat */
+    const double maxDrawVol_L = 1.;
+    const double ambientT_C = 20.;
+    const double externalT_C = 20.;
+
+    //
+    hpwh.setTankToTemperature(20.);
+    hpwh.setInletT(5.);
+
+    constexpr double testDuration_min = 60.;
+    bool result = true;
+    int i_min = 0;
+    do
     {
-        // get preset model
-        HPWH hpwh;
-        const std::string modelName = "AOSmithHPTS50";
-        hpwh.initPreset(modelName);
+        double t_min = static_cast<double>(i_min);
 
-        const double maxDrawVol_L = 1.;
-        const double ambientT_C = 20.;
-        const double externalT_C = 20.;
+        double flowFac = sin(Pi * t_min / testDuration_min) - 0.5;
+        flowFac += fabs(flowFac); // semi-sinusoidal flow profile
+        double drawVol_L = flowFac * maxDrawVol_L;
 
-        //
-        hpwh.setTankToTemperature(20.);
-        hpwh.setInletT(5.);
-
-        constexpr double testDuration_min = 60.;
-        bool result = true;
-        int i_min = 0;
-        do
-        {
-            double t_min = static_cast<double>(i_min);
-
-            double flowFac = sin(Pi * t_min / testDuration_min) - 0.5;
-            flowFac += fabs(flowFac); // semi-sinusoidal flow profile
-            double drawVol_L = flowFac * maxDrawVol_L;
-
-            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
-            EXPECT_NO_THROW(hpwh.runOneStep(drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW))
-                << "Failure in hpwh.runOneStep.";
-            result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
-
-            ++i_min;
-        } while (result && (i_min < testDuration_min));
-
-        EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
-    }
-
-    /* storage tank with extra heat (solar) */
-    {
-        // get preset model
-        HPWH hpwh;
-        const std::string modelName = "StorageTank";
-        hpwh.initPreset(modelName);
-
-        const double maxDrawVol_L = 1.;
-        const double ambientT_C = 20.;
-        const double externalT_C = 20.;
-
-        //
-        std::vector<double> nodePowerExtra_W = {1000.};
-        hpwh.setTankToTemperature(20.);
-        hpwh.setInletT(5.);
-
-        constexpr double testDuration_min = 60.;
-        bool result = true;
-        int i_min = 0;
-        do
-        {
-            double t_min = static_cast<double>(i_min);
-
-            double flowFac = sin(Pi * t_min / testDuration_min) - 0.5;
-            flowFac += fabs(flowFac); // semi-sinusoidal flow profile
-            double drawVol_L = flowFac * maxDrawVol_L;
-
-            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
-            EXPECT_NO_THROW(hpwh.runOneStep(
-                drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW, 0., 0., &nodePowerExtra_W))
-                << "Failure in hpwh.runOneStep.";
-            result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
-
-            ++i_min;
-        } while (result && (i_min < testDuration_min));
-
-        EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
-    }
-
-    /* high draw */
-    {
-        // get preset model
-        HPWH hpwh;
-        const std::string modelName = "AOSmithHPTS50";
-        hpwh.initPreset(modelName);
-
-        hpwh.setInletT(5.);
-        const double ambientT_C = 20.;
-        const double externalT_C = 20.;
-
-        bool result = true;
-
-        //
-        hpwh.setTankToTemperature(20.);
-        double drawVol_L = 1.01 * hpwh.getTankVolume_L(); // > tank volume
         double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
-
         EXPECT_NO_THROW(hpwh.runOneStep(drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW))
             << "Failure in hpwh.runOneStep.";
         result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
 
-        //
-        hpwh.setTankToTemperature(20.);
-        drawVol_L = 2. * hpwh.getTankVolume_L(); // > tank volume
-        prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+        ++i_min;
+    } while (result && (i_min < testDuration_min));
 
-        EXPECT_NO_THROW(hpwh.runOneStep(drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW))
+    EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
+}
+
+/* storage tank with extra heat (solar) */
+TEST_F(EnergyBalanceTest, StorageTankWithSolar)
+{
+    HPWH hpwh;
+    const std::string modelName = "StorageTank";
+    hpwh.initPreset(modelName);
+
+    const double maxDrawVol_L = 1.;
+    const double ambientT_C = 20.;
+    const double externalT_C = 20.;
+
+    //
+    std::vector<double> nodePowerExtra_W = {1000.};
+    hpwh.setTankToTemperature(20.);
+    hpwh.setInletT(5.);
+
+    constexpr double testDuration_min = 60.;
+    bool result = true;
+    int i_min = 0;
+    do
+    {
+        double t_min = static_cast<double>(i_min);
+
+        double flowFac = sin(Pi * t_min / testDuration_min) - 0.5;
+        flowFac += fabs(flowFac); // semi-sinusoidal flow profile
+        double drawVol_L = flowFac * maxDrawVol_L;
+
+        double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+        EXPECT_NO_THROW(hpwh.runOneStep(
+            drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW, 0., 0., &nodePowerExtra_W))
             << "Failure in hpwh.runOneStep.";
         result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
 
-        EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
-    }
+        ++i_min;
+    } while (result && (i_min < testDuration_min));
 
-    /* two inlets */
+    EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
+}
+
+/* high draw */
+TEST_F(EnergyBalanceTest, highDraw)
+{
+    // get preset model
+    HPWH hpwh;
+    const std::string modelName = "AOSmithHPTS50";
+    hpwh.initPreset(modelName);
+
+    hpwh.setInletT(5.);
+    const double ambientT_C = 20.;
+    const double externalT_C = 20.;
+
+    bool result = true;
+
+    //
+    hpwh.setTankToTemperature(20.);
+    double drawVol_L = 1.01 * hpwh.getTankVolume_L(); // > tank volume
+    double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+
+    EXPECT_NO_THROW(hpwh.runOneStep(drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW))
+        << "Failure in hpwh.runOneStep.";
+    result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
+
+    //
+    hpwh.setTankToTemperature(20.);
+    drawVol_L = 2. * hpwh.getTankVolume_L(); // > tank volume
+    prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+
+    EXPECT_NO_THROW(hpwh.runOneStep(drawVol_L, ambientT_C, externalT_C, HPWH::DR_ALLOW))
+        << "Failure in hpwh.runOneStep.";
+    result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
+
+    EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
+}
+
+/* two inlets */
+TEST_F(EnergyBalanceTest, twoInlets)
+{
     {
         // get preset model
         HPWH hpwh;
@@ -146,7 +150,6 @@ TEST(EnergyBalanceTest, energyBalance)
             double inlet1T_C = 5.;
             double inlet2T_C = 60.;
 
-
             double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
             hpwh.runOneStep(inlet1T_C,
                             drawVol_L,
@@ -160,8 +163,8 @@ TEST(EnergyBalanceTest, energyBalance)
                 inlet1Vol_L, inlet1T_C, inlet2Vol_L, inlet2T_C, prevHeatContent_kJ, 1.e-6))
                 << "Failure in two-inlet test:" << modelName;
         }
-        { // inlets at 1/4 and 3/4 heights
-            hpwh.setInletByFraction(0.25); // node 3
+        {                                   // inlets at 1/4 and 3/4 heights
+            hpwh.setInletByFraction(0.25);  // node 3
             hpwh.setInlet2ByFraction(0.75); // node 9
             hpwh.setTankToTemperature(53.);
             double inlet1T_C = 5.;

--- a/test/unit_tests/energyBalanceTest.cpp
+++ b/test/unit_tests/energyBalanceTest.cpp
@@ -136,16 +136,16 @@ TEST(EnergyBalanceTest, energyBalance)
         double inlet1Vol_L = 0.6 * drawVol_L;            // split between two inlets
         double inlet2Vol_L = drawVol_L - inlet1Vol_L;
 
-        double inlet1T_C = 5.;
-        double inlet2T_C = 60.;
-
         const double ambientT_C = 20.;
         const double externalT_C = 20.;
 
-        { // inleta at bottom and top of tank
+        { // inlets at bottom and top of tank
             hpwh.setInletByFraction(0.);
             hpwh.setInlet2ByFraction(1.);
             hpwh.setTankToTemperature(53.);
+            double inlet1T_C = 5.;
+            double inlet2T_C = 60.;
+
 
             double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
             hpwh.runOneStep(inlet1T_C,
@@ -161,9 +161,51 @@ TEST(EnergyBalanceTest, energyBalance)
                 << "Failure in two-inlet test:" << modelName;
         }
         { // inlets at 1/4 and 3/4 heights
-            hpwh.setInletByFraction(0.25);
-            hpwh.setInlet2ByFraction(0.75);
+            hpwh.setInletByFraction(0.25); // node 3
+            hpwh.setInlet2ByFraction(0.75); // node 9
             hpwh.setTankToTemperature(53.);
+            double inlet1T_C = 5.;
+            double inlet2T_C = 60.;
+
+            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+            hpwh.runOneStep(inlet1T_C,
+                            drawVol_L,
+                            ambientT_C,
+                            externalT_C,
+                            HPWH::DR_ALLOW,
+                            inlet2Vol_L,
+                            inlet2T_C);
+
+            EXPECT_TRUE(hpwh.isEnergyBalanced(
+                inlet1Vol_L, inlet1T_C, inlet2Vol_L, inlet2T_C, prevHeatContent_kJ, 1.e-6))
+                << "Failure in two-inlet test:" << modelName;
+        }
+        { // invert inlets
+            hpwh.setInletByFraction(1.);
+            hpwh.setInlet2ByFraction(0.);
+            hpwh.setTankToTemperature(53.);
+            double inlet1T_C = 5.;
+            double inlet2T_C = 60.;
+
+            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+            hpwh.runOneStep(inlet1T_C,
+                            drawVol_L,
+                            ambientT_C,
+                            externalT_C,
+                            HPWH::DR_ALLOW,
+                            inlet2Vol_L,
+                            inlet2T_C);
+
+            EXPECT_TRUE(hpwh.isEnergyBalanced(
+                inlet1Vol_L, inlet1T_C, inlet2Vol_L, inlet2T_C, prevHeatContent_kJ, 1.e-6))
+                << "Failure in two-inlet test:" << modelName;
+        }
+        { // swap temps
+            hpwh.setInletByFraction(0.);
+            hpwh.setInlet2ByFraction(1.);
+            hpwh.setTankToTemperature(53.);
+            double inlet1T_C = 60.;
+            double inlet2T_C = 5.;
 
             double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
             hpwh.runOneStep(inlet1T_C,

--- a/test/unit_tests/energyBalanceTest.cpp
+++ b/test/unit_tests/energyBalanceTest.cpp
@@ -95,8 +95,8 @@ TEST(EnergyBalanceTest, energyBalance)
     {
         // get preset model
         HPWH hpwh;
-        const std::string sModelName = "AOSmithHPTS50";
-        hpwh.initPreset(sModelName);
+        const std::string modelName = "AOSmithHPTS50";
+        hpwh.initPreset(modelName);
 
         hpwh.setInletT(5.);
         const double ambientT_C = 20.;
@@ -122,6 +122,61 @@ TEST(EnergyBalanceTest, energyBalance)
             << "Failure in hpwh.runOneStep.";
         result &= hpwh.isEnergyBalanced(drawVol_L, prevHeatContent_kJ, 1.e-6);
 
-        EXPECT_TRUE(result) << "Energy balance failed for model " << sModelName;
+        EXPECT_TRUE(result) << "Energy balance failed for model " << modelName;
+    }
+
+    /* two inlets */
+    {
+        // get preset model
+        HPWH hpwh;
+        const std::string modelName = "AOSmithHPTS50";
+        hpwh.initPreset(modelName);
+
+        double drawVol_L = 0.4 * hpwh.getTankVolume_L(); // < tank volume
+        double inlet1Vol_L = 0.6 * drawVol_L;            // split between two inlets
+        double inlet2Vol_L = drawVol_L - inlet1Vol_L;
+
+        double inlet1T_C = 5.;
+        double inlet2T_C = 60.;
+
+        const double ambientT_C = 20.;
+        const double externalT_C = 20.;
+
+        { // inleta at bottom and top of tank
+            hpwh.setInletByFraction(0.);
+            hpwh.setInlet2ByFraction(1.);
+            hpwh.setTankToTemperature(53.);
+
+            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+            hpwh.runOneStep(inlet1T_C,
+                            drawVol_L,
+                            ambientT_C,
+                            externalT_C,
+                            HPWH::DR_ALLOW,
+                            inlet2Vol_L,
+                            inlet2T_C);
+
+            EXPECT_TRUE(hpwh.isEnergyBalanced(
+                inlet1Vol_L, inlet1T_C, inlet2Vol_L, inlet2T_C, prevHeatContent_kJ, 1.e-6))
+                << "Failure in two-inlet test:" << modelName;
+        }
+        { // inlets at 1/4 and 3/4 heights
+            hpwh.setInletByFraction(0.25);
+            hpwh.setInlet2ByFraction(0.75);
+            hpwh.setTankToTemperature(53.);
+
+            double prevHeatContent_kJ = hpwh.getTankHeatContent_kJ();
+            hpwh.runOneStep(inlet1T_C,
+                            drawVol_L,
+                            ambientT_C,
+                            externalT_C,
+                            HPWH::DR_ALLOW,
+                            inlet2Vol_L,
+                            inlet2T_C);
+
+            EXPECT_TRUE(hpwh.isEnergyBalanced(
+                inlet1Vol_L, inlet1T_C, inlet2Vol_L, inlet2T_C, prevHeatContent_kJ, 1.e-6))
+                << "Failure in two-inlet test:" << modelName;
+        }
     }
 }


### PR DESCRIPTION
Brings in the patch code used in cse from [two-inlet-fix](https://github.com/bigladder/HPWHsim/tree/two-inlet-fix).

Expands tests to check influences of inlet height and draw temperature (draw volumes fixed).
'Tank::updateNodes' (formerly `updateTankTemps`) draws at most one node volume at a time. Each node transfers a volume (heat) to the outlet (usually at the top node), and/or to the node above, and receives a volume ( usually -heat ) from an inlet connected to that node (usually at the bottom node), and/or from the node below.

The volume drawn from node $i$ into node $i+1$ is reduced by the total inlet volume above the node $i$, so a cumulative total is needed of the volume drawn by each inlet working from the top node down.

HPWHsim is coded for two inlets,  at different heights, and which accept different draw volumes and temperatures. 

The multiple inlet draw sequence could be generalized and improved using a std::vector of inlets, rather than an assumed two inlets (one of which is rarely used.)