### PR TITLE
Fix assignment in conditional.

### DIFF
--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3737,7 +3737,7 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
                 she.hot_side_temperature_offset);
         checkTo(condenser->secondaryHeatExchanger.extraPumpPower_W,
                 she.extra_pump_power_is_set,
-                she.extra_pumpgit add._power);
+                she.extra_pump_power);
     }
 
     cwhs.heat_source_configurations_is_set = true;

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3724,9 +3724,8 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
             cwhs.fixed_flow_rate,
             condenser->isMultipass);
 
-    cwhs.secondary_heat_exchanger_is_set =
-        (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.);
-    if (cwhs.secondary_heat_exchanger_is_set)
+    if ((cwhs.secondary_heat_exchanger_is_set =
+        (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.)))
     {
         auto& she = cwhs.secondary_heat_exchanger;
         checkTo(condenser->secondaryHeatExchanger.coldSideTemperatureOffset_dC,

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3737,7 +3737,7 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
                 she.hot_side_temperature_offset);
         checkTo(condenser->secondaryHeatExchanger.extraPumpPower_W,
                 she.extra_pump_power_is_set,
-                she.extra_pumpgit add ._power);
+                she.extra_pumpgit add._power);
     }
 
     cwhs.heat_source_configurations_is_set = true;

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3724,8 +3724,9 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
             cwhs.fixed_flow_rate,
             condenser->isMultipass);
 
-    if ((cwhs.secondary_heat_exchanger_is_set =
-             (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.)))
+    cwhs.secondary_heat_exchanger_is_set =
+        (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.);
+    if (cwhs.secondary_heat_exchanger_is_set)
     {
         auto& she = cwhs.secondary_heat_exchanger;
         checkTo(condenser->secondaryHeatExchanger.coldSideTemperatureOffset_dC,
@@ -3736,7 +3737,7 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
                 she.hot_side_temperature_offset);
         checkTo(condenser->secondaryHeatExchanger.extraPumpPower_W,
                 she.extra_pump_power_is_set,
-                she.extra_pump_power);
+                she.extra_pumpgit add ._power);
     }
 
     cwhs.heat_source_configurations_is_set = true;

--- a/src/HPWH.cc
+++ b/src/HPWH.cc
@@ -3724,8 +3724,9 @@ void HPWH::to(hpwh_data_model::central_water_heating_system::CentralWaterHeating
             cwhs.fixed_flow_rate,
             condenser->isMultipass);
 
-    if ((cwhs.secondary_heat_exchanger_is_set =
-        (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.)))
+    cwhs.secondary_heat_exchanger_is_set =
+        (condenser->secondaryHeatExchanger.extraPumpPower_W > 0.);
+    if (cwhs.secondary_heat_exchanger_is_set)
     {
         auto& she = cwhs.secondary_heat_exchanger;
         checkTo(condenser->secondaryHeatExchanger.coldSideTemperatureOffset_dC,


### PR DESCRIPTION
The assignment in conditional generates a warning using msvc v142, but not with v143. For compatibility with v142, the assignment was moved outside the conditional.